### PR TITLE
Allow shell commands in config file

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -47,7 +47,7 @@ __author__  = 'Eric Davis'
 
 import inspect
 
-import sys, os, re, urllib, getopt, shlex
+import sys, os, re, urllib, getopt, shlex, subprocess
 import codecs, locale, csv, threading, getpass
 from Queue import Queue
 from ConfigParser import RawConfigParser
@@ -1168,6 +1168,14 @@ def GetConfig(config, key, default):
     except:
         value = default
 
+    if value and value.startswith('`'):
+        # Value is a shell command
+        cmd = value.strip()[1:-1]
+        parts = []
+        for part in cmd.split():
+            parts.append(os.path.expanduser(part))
+        value = subprocess.check_output(parts).strip()
+
     return value
 
 
@@ -1291,7 +1299,7 @@ def BowChickaWowWow():
     calOwnerColor = \
         GetColor(GetConfig(cfg, 'cal-owner-color', 'cyan'), True)
     calEditorColor = \
-        GetColor(GetConfig(cfg, 'cal-editor-color', 'green'), True) 
+        GetColor(GetConfig(cfg, 'cal-editor-color', 'green'), True)
     calContributorColor = \
         GetColor(GetConfig(cfg, 'cal-contributor-color', 'default'), True)
     calReadColor = \


### PR DESCRIPTION
I like to encrypt my password in the config file, so it looks like this:

```
[gcalcli]
user: graham@example.com
pw: `gpg --decrypt ~/.googlepw.gpg`
```

This pull request looks for ` as the first character of a config value, and if found runs it through subprocess.check_output.

Original ticket: http://code.google.com/p/gcalcli/issues/detail?id=80
