### PR TITLE
Add organizer and attendees

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1182,6 +1182,31 @@ class gcalcli:
                     print "Description:\n%s" % ve.description.value
                 event.content = atom.Content(text=ve.description.value)
 
+            if hasattr(ve, 'organizer'):
+                DebugPrint("ORGANIZER: %s\n" % ve.organizer.value)
+
+                if ve.organizer.value.startswith("MAILTO:"):
+                    email = ve.organizer.value[7:]
+                else:
+                    email = ve.organizer.value
+                if verbose:
+                    print "organizer:\n%s" % email
+                event.who.append(gdata.calendar.Who(ve.organizer.name, email, rel='ORGANIZER'))
+
+            if hasattr(ve, 'attendee_list'):
+                DebugPrint("ATTENDEE_LIST : %s\n" % ve.attendee_list)
+                if verbose:
+                    print "attendees:"
+                for attendee in ve.attendee_list:
+                    if attendee.value.startswith("MAILTO:"):
+                        email = attendee.value[7:]
+                    else:
+                        email = attendee.value
+                    if verbose:
+                        print " %s" % email
+
+                    event.who.append(gdata.calendar.Who(attendee.name, email, rel='ATTENDEE'))
+
             if not verbose:
                 try:
                     self.gcal.InsertEvent(event, self._TargetCalendar())


### PR DESCRIPTION
Fix for #27 .  I've tested this using the following ICS:

```
BEGIN:VCALENDAR
METHOD:REQUEST
PRODID:Microsoft Exchange Server 2010
VERSION:2.0
BEGIN:VTIMEZONE
TZID:Romance Standard Time
BEGIN:STANDARD
DTSTART:16010101T030000
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=10
END:STANDARD
BEGIN:DAYLIGHT
DTSTART:16010101T020000
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=3
END:DAYLIGHT
END:VTIMEZONE
BEGIN:VEVENT
ORGANIZER;CN="Hansen, Sune":MAILTO:Sune.Hansen@acme.com
ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=tnielse3@csc.com:MAILTO:tnielse3@acme.com
ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=Kent Michaelsen (kmichaelsen@acme.com):MAILTO:kmichaelsen@acme.com
ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN="Costa, Jorge":MAILTO:Jorge.Costa@acme.com
ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:mholden6@acme.com
DESCRIPTION;LANGUAGE=en-US:All\,\n\nThis is a Placeholder for next week’s TOI –\nWebex and Con Call details will follow.\n\n/Sune\n\n
SUMMARY;LANGUAGE=en-US:SnapCreator TOI
DTSTART;TZID=Romance Standard Time:20121024T113000
DTEND;TZID=Romance Standard Time:20121024T133000
UID:040000008200E00074C5B7101A82E00800000000E082784ADAADCD0100000000000000001000000078F78DCB98419F4889FE6A4B96A6DAF2
CLASS:PUBLIC
PRIORITY:5
DTSTAMP:20121019T071532Z
TRANSP:OPAQUE
STATUS:CONFIRMED
SEQUENCE:0
LOCATION;LANGUAGE=en-US:Webex and Con Call
X-MICROSOFT-CDO-APPT-SEQUENCE:0
X-MICROSOFT-CDO-OWNERAPPTID:2104731612
X-MICROSOFT-CDO-BUSYSTATUS:TENTATIVE
X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
X-MICROSOFT-CDO-IMPORTANCE:1
X-MICROSOFT-CDO-INSTTYPE:0
X-MICROSOFT-DISALLOW-COUNTER:FALSE
BEGIN:VALARM
ACTION:DISPLAY
DESCRIPTION:REMINDER
TRIGGER;RELATED=START:-PT15M
END:VALARM
END:VEVENT
END:VCALENDAR
```

I've removed the `CN` from one attendee.  Format requires that a `MAILTO:` in the `ATTENDEE`, but we check and only strip if it's actually there.  Roles are not currently used, but could be added, same goes for status.

Interesting side note: Using `event.organizer` always leads to a Redirect error.  Might be because this is using the deprecated 2.0 GData libraries instead of the 3.0 API. I'll probably look at what it will take to move the new API.
