### PR TITLE
Fixing error outputting so as not to cause a stacktrace/additional errors

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1022,7 +1022,7 @@ class gcalcli:
         try:
             self.gcal.InsertEvent(quickEvent, self._TargetCalendar())
         except Exception, e:
-            PrintErrMsg("Error: " + e["reason"] + "\n")
+            PrintErrMsg("Error: %s -- %s\n" % (e[0]["reason"], e[0]["body"]))
             sys.exit(1)
 
 
@@ -1186,7 +1186,7 @@ class gcalcli:
                 try:
                     self.gcal.InsertEvent(event, self._TargetCalendar())
                 except Exception, e:
-                    PrintErrMsg("Error: " + e[0] + "\n")
+                    PrintErrMsg("Error: %s -- %s\n" % (e[0]["reason"], e[0]["body"]))
                     sys.exit(1)
                 continue
 
@@ -1196,7 +1196,7 @@ class gcalcli:
                 try:
                     self.gcal.InsertEvent(event, self._TargetCalendar())
                 except Exception, e:
-                    PrintErrMsg("Error: " + e[0] + "\n")
+                    PrintErrMsg("Error: %s -- %s\n" % (e[0]["reason"], e[0]["body"]))
                     sys.exit(1)
             elif val == 's':
                 continue


### PR DESCRIPTION
Anytime the request fails right now I end up with a stack trace and an "index must be int not str" error.  This seems to  correct the error and properly prints out the real error message without having to access `["reason"]` directly.
