### PR TITLE
Add option to print event description with agenda.

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -72,122 +72,122 @@ gcalcli [options] command [command args]
 
  Options:
 
-  --help                   this usage text
+  --help                     this usage text
 
-  --version                version information
+  --version                  version information
 
-  --config <file>          config file to read (default is '~/.gcalclirc')
+  --config <file>            config file to read (default is '~/.gcalclirc')
 
-  --user <username>        google username
+  --user <username>          google username
 
-  --pw <password>          password
+  --pw <password>            password
 
-  --cals [all,             'calendars' to work with (default is all calendars)
-          default,         - default (your default main calendar)
-          owner,           - owner (your owned calendars)
-          editor,          - editor (editable calendar)
-          contributor,     - contributor (non-owner but able to edit)
-          read,            - read (read only calendars)
-          freebusy]        - freebusy (only free/busy info visible)
+  --cals [all,               'calendars' to work with (default is all calendars)
+          default,           - default (your default main calendar)
+          owner,             - owner (your owned calendars)
+          editor,            - editor (editable calendar)
+          contributor,       - contributor (non-owner but able to edit)
+          read,              - read (read only calendars)
+          freebusy]          - freebusy (only free/busy info visible)
 
-  --cal <name>[#color]     'calendar' to work with (default is all calendars)
-                           - you can specify a calendar by name or by substring
-                             which can match multiple calendars
-                           - you can use multiple '--cal' arguments on the
-                             command line
-                           - in the config file specify multiple calendars in
-                             quotes separated by commas as:
-                               cal: "foo", "bar", "my cal"
-                           - an optional color override can be specified per
-                             calendar using the ending hashtag:
-                               --cal "Eric Davis"#green --cal foo#red
-                             or via the config file:
-                               cal: "foo"#red, "bar"#yellow, "my cal"#green
+  --cal <name>[#color]       'calendar' to work with (default is all calendars)
+                             - you can specify a calendar by name or by substring
+                               which can match multiple calendars
+                             - you can use multiple '--cal' arguments on the
+                               command line
+                             - in the config file specify multiple calendars in
+                               quotes separated by commas as:
+                                 cal: "foo", "bar", "my cal"
+                             - an optional color override can be specified per
+                               calendar using the ending hashtag:
+                                 --cal "Eric Davis"#green --cal foo#red
+                               or via the config file:
+                                 cal: "foo"#red, "bar"#yellow, "my cal"#green
 
-  --24hr                   show all dates in 24 hour format
+  --24hr                     show all dates in 24 hour format
 
-  --details                show all event details (i.e. length, location,
-                           reminders, contents)
+  --details                  show all event details (i.e. length, location,
+                             reminders, contents)
 
-  --ignore-started         ignore old or already started events
-                           - when used with the 'agenda' command, ignore events
-                             that have already started and are in-progress with
-                             respect to the specified [start] time
-                           - when used with the 'search' command, ignore events
-                             that have already occurred and only show future
-                             events
+  --ignore-started           ignore old or already started events
+                             - when used with the 'agenda' command, ignore events
+                               that have already started and are in-progress with
+                               respect to the specified [start] time
+                             - when used with the 'search' command, ignore events
+                               that have already occurred and only show future
+                               events
 
-  --width                  the number of characters to use for each column in
-                           the 'calw' and 'calm' command outputs (default is 10)
+  --width                    the number of characters to use for each column in
+                             the 'calw' and 'calm' command outputs (default is 10)
 
-  --mon                    week begins with Monday for 'calw' and 'calm' command
-                           outputs (default is Sunday)
+  --mon                      week begins with Monday for 'calw' and 'calm' command
+                             outputs (default is Sunday)
 
-  --nc                     don't use colors
+  --nc                       don't use colors
 
-  --cal-owner-color        specify the colors used for the calendars and dates
-  --cal-editor-color       each of these argument requires a <color> argument
-  --cal-contributor-color  which must be one of [ default, black, brightblack,
-  --cal-read-color         red, brightred, green, brightgreen, yellow,
-  --cal-freebusy-color     brightyellow, blue, brightblue, magenta,
-  --date-color             brightmagenta, cyan, brightcyan, white,
-  --border-color           brightwhite ]
+  --cal-owner-color          specify the colors used for the calendars and dates
+  --cal-editor-color         each of these argument requires a <color> argument
+  --cal-contributor-color    which must be one of [ default, black, brightblack,
+  --cal-read-color           red, brightred, green, brightgreen, yellow,
+  --cal-freebusy-color       brightyellow, blue, brightblue, magenta,
+  --date-color               brightmagenta, cyan, brightcyan, white,
+  --border-color             brightwhite ]
 
-  --tsv                    tab-separated output for 'agenda'. Format is:
-                           'date' 'start' 'end' 'title' 'location' 'description'
+  --tsv                      tab-separated output for 'agenda'. Format is:
+                             'date' 'start' 'end' 'title' 'location' 'description'
 
  Commands:
 
-  list                     list all calendars
+  list                       list all calendars
 
-  search <text>            search for events
-                           - only matches whole words
+  search <text>              search for events
+                             - only matches whole words
 
-  agenda [-d] [start] [end]get an agenda for a time period
-                           - start time default is 12am today
-                           - end time default is 5 days from start
-                           - example time strings:
-                              '9/24/2007'
-                              'Sep 24 2007 3:30pm'
-                              '2007-09-24T15:30'
-                              '2007-09-24T15:30-8:00'
-                              '20070924T15'
-                              '8am'
-                            - if -d is given events description is also printed.
+  agenda [-d] [start] [end]  get an agenda for a time period
+                             - start time default is 12am today
+                             - end time default is 5 days from start
+                             - example time strings:
+                                '9/24/2007'
+                                'Sep 24 2007 3:30pm'
+                                '2007-09-24T15:30'
+                                '2007-09-24T15:30-8:00'
+                                '20070924T15'
+                                '8am'
+                              - if -d is given events description is also printed.
 
-  calw <weeks> [start]     get a week based agenda in a nice calendar format
-                           - weeks is the number of weeks to display
-                           - start time default is beginning of this week
-                           - note that all events for the week(s) are displayed
+  calw <weeks> [start]       get a week based agenda in a nice calendar format
+                             - weeks is the number of weeks to display
+                             - start time default is beginning of this week
+                             - note that all events for the week(s) are displayed
 
-  calm [start]             get a month agenda in a nice calendar format
-                           - start time default is the beginning of this month
-                           - note that all events for the month are displayed
-                             and only one month will be displayed
+  calm [start]               get a month agenda in a nice calendar format
+                             - start time default is the beginning of this month
+                             - note that all events for the month are displayed
+                               and only one month will be displayed
 
-  quick <text>             quick add an event to a calendar
-                           - if a --cal is not specified then the event is
-                             added to the default calendar
-                           - example:
-                              'Dinner with Eric 7pm tomorrow'
-                              '5pm 10/31 Trick or Treat'
+  quick <text>               quick add an event to a calendar
+                             - if a --cal is not specified then the event is
+                               added to the default calendar
+                             - example:
+                                'Dinner with Eric 7pm tomorrow'
+                                '5pm 10/31 Trick or Treat'
 
-  import [-v] [file]       import an ics/vcal file to a calendar
-                           - if a --cal is not specified then the event is
-                             added to the default calendar
-                           - if a file is not specified then the data is read
-                             from standard input
-                           - if -v is given then each event in the file is
-                             displayed and you're given the option to import
-                             or skip it, by default everything is imported
-                             quietly without any interaction
+  import [-v] [file]         import an ics/vcal file to a calendar
+                             - if a --cal is not specified then the event is
+                               added to the default calendar
+                             - if a file is not specified then the data is read
+                               from standard input
+                             - if -v is given then each event in the file is
+                               displayed and you're given the option to import
+                               or skip it, by default everything is imported
+                               quietly without any interaction
 
-  remind <mins> <command>  execute command if event occurs within <mins>
-                           minutes time ('%s' in <command> is replaced with
-                           event start time and title text)
-                           - <mins> default is 10
-                           - default command:
-                              'notify-send -u critical -a gcalcli %s'
+  remind <mins> <command>    execute command if event occurs within <mins>
+                             minutes time ('%s' in <command> is replaced with
+                             event start time and title text)
+                             - <mins> default is 10
+                             - default command:
+                                'notify-send -u critical -a gcalcli %s'
 ''')
     sys.exit(1)
 


### PR DESCRIPTION
I usually want to see events description in agenda. The "--details" option already shows this but also shows other information and clutters the event entries so I added a new option to show only the description with proper indent.
