### PR TITLE
added missing timedelta import

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -53,6 +53,7 @@ from Queue import Queue
 from ConfigParser import RawConfigParser
 from gdata.calendar.service import *
 from datetime import datetime
+from datetime import timedelta
 from dateutil.tz import *
 from dateutil.parser import *
 from dateutil.rrule import *


### PR DESCRIPTION
```
$ python2 ./gcalcli --detail-descr agenda
Traceback (most recent call last):
  File "./gcalcli", line 1899, in <module>
    BowChickaWowWow()
  File "./gcalcli", line 1779, in BowChickaWowWow
    gcal.AgendaQuery()
  File "./gcalcli", line 1066, in AgendaQuery
    end = (start + timedelta(days=self.agendaLength))
NameError: global name 'timedelta' is not defined
```

Just missing timedelta import.
