### PR TITLE
don't show description containing only whitespace chars

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -918,7 +918,7 @@ class gcalcli:
                     PrintMsg(CLR_NRM(), str)
 
             if self.detailDescr:
-                if event.content and event.content.text:
+                if event.content and event.content.text and event.content.text.strip():
                     descrIndent = detailsIndent + '  '
                     marker = descrIndent + "-" * \
                             (self.detailDescrWidth - len(descrIndent))


### PR DESCRIPTION
It's quite easy to have events which have empty looking descriptions but actually contain only whitespace characters. It's no use to show these.
