### PR TITLE
Added custom color option for Conky

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,7 @@ gcalcli [options] command [command args]
   --[no]includerc          Whether the ~/.gcalclirc should be used in addition
                            to the one in the config folder
 
-  --calendar <name>[#color]
+  --calendar <name>[##color]
                            'calendar' to work with (default is all calendars)
                            - you can specify a calendar by name or by substring
                              which can match multiple calendars
@@ -87,7 +87,7 @@ gcalcli [options] command [command args]
                              command line for the query commands
                            - an optional color override can be specified per
                              calendar using the ending hashtag:
-                               --cal "Eric Davis"#green --cal foo#red
+                               --cal "Eric Davis"##green --cal foo##red
 
   --[no]military           show all dates in 24 hour format (default = False)
 

--- a/gcalcli
+++ b/gcalcli
@@ -163,6 +163,7 @@ __API_CLIENT_SECRET__ = '3tZSxItw6_VnZMezQwC8lUqy'
 # These are standard libraries and should never fail
 import sys, os, re, gflags, shlex, time
 import locale, textwrap, signal
+import string
 from Queue import Queue
 from datetime import datetime, timedelta, date
 from unicodedata import east_asian_width
@@ -1877,7 +1878,7 @@ def ValidColor(value):
         return True
     else:
         #Check if real Conky color
-        return True if ("${color " in value) else False
+        return True if ("${color " in value) or (len(value) == 7 and all([c in string.hexdigits for c in value[1:]])) else False
 
 
 def GetColor(value):
@@ -2037,52 +2038,52 @@ gflags.RegisterValidator("color_border",
 
 
 gflags.RegisterValidator("conky_color_owner",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_writer",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_reader",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_freebusy",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_date",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_now_marker",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color_border",
-                         lambda value: ValidColor(value) != None)
+                         lambda value: ValidColor(value))
 
 gflags.RegisterValidator("conky_color0",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color1",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color2",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color3",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color4",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color5",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color6",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color7",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color8",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color9",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color10",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color11",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color12",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color13",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color14",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 gflags.RegisterValidator("conky_color15",
-                         lambda value: GetColor(value) != None)
+                         lambda value: ValidColor(value))
 
 gflags.ADOPT_module_key_flags(gflags)
 

--- a/gcalcli
+++ b/gcalcli
@@ -219,51 +219,51 @@ class CLR:
 
     useColor = True
     conky    = False
+    
+    def __init__(self, value = None):
+            self.color = value if value else self.color
 
     def __str__(self):
         return self.color if self.useColor else ""
 
-class CLR_NRM(CLR):   color = "\033[0m"
-class CLR_BLK(CLR):   color = "\033[0;30m"
-class CLR_BRBLK(CLR): color = "\033[30;1m"
-class CLR_RED(CLR):   color = "\033[0;31m"
-class CLR_BRRED(CLR): color = "\033[31;1m"
-class CLR_GRN(CLR):   color = "\033[0;32m"
-class CLR_BRGRN(CLR): color = "\033[32;1m"
-class CLR_YLW(CLR):   color = "\033[0;33m"
-class CLR_BRYLW(CLR): color = "\033[33;1m"
-class CLR_BLU(CLR):   color = "\033[0;34m"
-class CLR_BRBLU(CLR): color = "\033[34;1m"
-class CLR_MAG(CLR):   color = "\033[0;35m"
-class CLR_BRMAG(CLR): color = "\033[35;1m"
-class CLR_CYN(CLR):   color = "\033[0;36m"
-class CLR_BRCYN(CLR): color = "\033[36;1m"
-class CLR_WHT(CLR):   color = "\033[0;37m"
-class CLR_BRWHT(CLR): color = "\033[37;1m"
-class CLR_CUSTOM(CLR):
-    def __init__(self, value = ""):
-        self.color = value 
+class CLR_NRM(CLR):     color = "\033[0m"
+class CLR_BLK(CLR):     color = "\033[0;30m"
+class CLR_BRBLK(CLR):   color = "\033[30;1m"
+class CLR_RED(CLR):     color = "\033[0;31m"
+class CLR_BRRED(CLR):   color = "\033[31;1m"
+class CLR_GRN(CLR):     color = "\033[0;32m"
+class CLR_BRGRN(CLR):   color = "\033[32;1m"
+class CLR_YLW(CLR):     color = "\033[0;33m"
+class CLR_BRYLW(CLR):   color = "\033[33;1m"
+class CLR_BLU(CLR):     color = "\033[0;34m"
+class CLR_BRBLU(CLR):   color = "\033[34;1m"
+class CLR_MAG(CLR):     color = "\033[0;35m"
+class CLR_BRMAG(CLR):   color = "\033[35;1m"
+class CLR_CYN(CLR):     color = "\033[0;36m"
+class CLR_BRCYN(CLR):   color = "\033[36;1m"
+class CLR_WHT(CLR):     color = "\033[0;37m"
+class CLR_BRWHT(CLR):   color = "\033[37;1m"
+class CLR_CUSTOM(CLR):  color = ""
 
 def SetConkyColors():
-    # XXX these colors should be configurable
     CLR.conky       = True
     CLR_NRM.color   = ""
-    CLR_BLK.color   = "${color black}"
-    CLR_BRBLK.color = "${color black}"
-    CLR_RED.color   = "${color red}"
-    CLR_BRRED.color = "${color red}"
-    CLR_GRN.color   = "${color green}"
-    CLR_BRGRN.color = "${color green}"
-    CLR_YLW.color   = "${color yellow}"
-    CLR_BRYLW.color = "${color yellow}"
-    CLR_BLU.color   = "${color blue}"
-    CLR_BRBLU.color = "${color blue}"
-    CLR_MAG.color   = "${color magenta}"
-    CLR_BRMAG.color = "${color magenta}"
-    CLR_CYN.color   = "${color cyan}"
-    CLR_BRCYN.color = "${color cyan}"
-    CLR_WHT.color   = "${color white}"
-    CLR_BRWHT.color = "${color white}"
+    CLR_BLK.color   = "${color " + FLAGS.conky_color0 + "}"
+    CLR_BRBLK.color = "${color " + FLAGS.conky_color8 + "}"
+    CLR_RED.color   = "${color " + FLAGS.conky_color1 + "}"
+    CLR_BRRED.color = "${color " + FLAGS.conky_color9 + "}"
+    CLR_GRN.color   = "${color " + FLAGS.conky_color2 + "}"
+    CLR_BRGRN.color = "${color " + FLAGS.conky_color10 + "}"
+    CLR_YLW.color   = "${color " + FLAGS.conky_color3 + "}"
+    CLR_BRYLW.color = "${color " + FLAGS.conky_color11 + "}"
+    CLR_BLU.color   = "${color " + FLAGS.conky_color4 + "}"
+    CLR_BRBLU.color = "${color " + FLAGS.conky_color12 + "}"
+    CLR_MAG.color   = "${color " + FLAGS.conky_color5 + "}"
+    CLR_BRMAG.color = "${color " + FLAGS.conky_color13 + "}"
+    CLR_CYN.color   = "${color " + FLAGS.conky_color6 + "}"
+    CLR_BRCYN.color = "${color " + FLAGS.conky_color14 + "}"
+    CLR_WHT.color   = "${color " + FLAGS.conky_color7 + "}"
+    CLR_BRWHT.color = "${color " + FLAGS.conky_color15 + "}"
 
 class ART:
 
@@ -1978,6 +1978,27 @@ gflags.DEFINE_string("conky_color_date", "yellow", "Color for the date in conky"
 gflags.DEFINE_string("conky_color_now_marker", "brightred", "Color for the now marker in conky")
 gflags.DEFINE_string("conky_color_border", "white", "Color of line borders in conky")
 
+
+
+gflags.DEFINE_string("conky_color0", "black", "Color used instead of black in conky")
+gflags.DEFINE_string("conky_color1", "red", "Color used instead of red in conky")
+gflags.DEFINE_string("conky_color2", "green", "Color used instead of green in conky")
+gflags.DEFINE_string("conky_color3", "yellow", "Color used instead of yellow in conky")
+gflags.DEFINE_string("conky_color4", "blue", "Color used instead of blue in conky")
+gflags.DEFINE_string("conky_color5", "magenta", "Color used instead of magenta in conky")
+gflags.DEFINE_string("conky_color6", "cyan", "Color used instead of cyan in conky")
+gflags.DEFINE_string("conky_color7", "white", "Color used instead of white in conky")
+gflags.DEFINE_string("conky_color8", "black", "Color used instead of bright black in conky")
+gflags.DEFINE_string("conky_color9", "red", "Color used instead of bright red in conky")
+gflags.DEFINE_string("conky_color10", "green", "Color used instead of bright green in conky")
+gflags.DEFINE_string("conky_color11", "yellow", "Color used instead of bright yellow in conky")
+gflags.DEFINE_string("conky_color12", "blue", "Color used instead of bright blue in conky")
+gflags.DEFINE_string("conky_color13", "magenta", "Color used instead of bright magenta in conky")
+gflags.DEFINE_string("conky_color14", "cyan", "Color used instead of bright cyan in conky")
+gflags.DEFINE_string("conky_color15", "white", "Color used instead of bright white in conky")
+
+
+
 gflags.DEFINE_string("locale", None, "System locale")
 
 gflags.DEFINE_integer("reminder", None, "Reminder minutes")
@@ -2030,7 +2051,38 @@ gflags.RegisterValidator("conky_color_now_marker",
 gflags.RegisterValidator("conky_color_border",
                          lambda value: ValidColor(value) != None)
 
-
+gflags.RegisterValidator("conky_color0",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color1",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color2",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color3",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color4",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color5",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color6",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color7",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color8",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color9",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color10",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color11",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color12",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color13",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color14",
+                         lambda value: GetColor(value) != None)
+gflags.RegisterValidator("conky_color15",
+                         lambda value: GetColor(value) != None)
 
 gflags.ADOPT_module_key_flags(gflags)
 

--- a/gcalcli
+++ b/gcalcli
@@ -1876,7 +1876,7 @@ def GetColor(value):
     if value in colors:
         return colors[value]
     else:
-        return CLR_CUSTOM(value) if CLR.conky else None
+        return CLR_CUSTOM(value) if FLAGS.conky else None
 
 def GetCalColors(calNames):
     calColors = {}

--- a/gcalcli
+++ b/gcalcli
@@ -240,7 +240,9 @@ class CLR_CYN(CLR):   color = "\033[0;36m"
 class CLR_BRCYN(CLR): color = "\033[36;1m"
 class CLR_WHT(CLR):   color = "\033[0;37m"
 class CLR_BRWHT(CLR): color = "\033[37;1m"
-
+class CLR_CUSTOM(CLR):
+    def __init__(self, value = ""):
+        self.color = value 
 
 def SetConkyColors():
     # XXX these colors should be configurable
@@ -262,7 +264,6 @@ def SetConkyColors():
     CLR_BRCYN.color = "${color cyan}"
     CLR_WHT.color   = "${color white}"
     CLR_BRWHT.color = "${color white}"
-
 
 class ART:
 
@@ -1875,12 +1876,12 @@ def GetColor(value):
     if value in colors:
         return colors[value]
     else:
-        return None
+        return CLR_CUSTOM(value) if CLR.conky else None
 
 def GetCalColors(calNames):
     calColors = {}
     for calName in calNames:
-        calNameParts = calName.split("#")
+        calNameParts = calName.split("##")
         calNameSimple = calNameParts[0]
         calColor = calColors.get(calNameSimple)
         if len(calNameParts) > 0:
@@ -2056,7 +2057,7 @@ def BowChickaWowWow():
     calColors = GetCalColors(FLAGS.calendar)
     calNamesFiltered = []
     for calName in FLAGS.calendar:
-        calNameSimple = calName.split("#")[0]
+        calNameSimple = calName.split("##")[0]
         calNamesFiltered.append(calNameSimple)
         calNameColors.append(calColors[calNameSimple])
     calNames = calNamesFiltered

--- a/gcalcli
+++ b/gcalcli
@@ -1853,6 +1853,33 @@ class gcalcli:
                     PrintErrMsg('Error: invalid input\n')
                     sys.exit(1)
 
+def ValidColor(value):
+    colors = [ 'default'       ,
+               'black'         ,
+               'brightblack'   ,
+               'red'           ,
+               'brightred'     ,
+               'green'         ,
+               'brightgreen'   ,
+               'yellow'        ,
+               'brightyellow'  ,
+               'blue'          ,
+               'brightblue'    ,
+               'magenta'       ,
+               'brightmagenta' ,
+               'cyan'          ,
+               'brightcyan'    ,
+               'white'         ,
+               'brightwhite'   ,
+               None             ]
+
+    if value in colors:
+        return True
+    else:
+        #Check if real Conky color
+        return True if ("${color " in value) else False
+
+
 def GetColor(value):
     colors = { 'default'       : CLR_NRM(),
                'black'         : CLR_BLK(),
@@ -1931,7 +1958,9 @@ gflags.DEFINE_integer("width", 10, "Set output width", short_name="w")
 gflags.DEFINE_bool("monday", False, "Start the week on Monday")
 gflags.DEFINE_bool("color", True, "Enable/Disable all color output")
 gflags.DEFINE_bool("lineart", True, "Enable/Disable line art")
-gflags.DEFINE_bool("conky", False, "Use Conky color codes")
+gflags.DEFINE_bool("conky", False, "Use Conky color codes and conky color settings. N.B: Non-conky color flags are not used if this flag is on")
+
+
 
 gflags.DEFINE_string("color_owner", "cyan", "Color for owned calendars")
 gflags.DEFINE_string("color_writer", "green", "Color for writable calendars")
@@ -1940,6 +1969,14 @@ gflags.DEFINE_string("color_freebusy", "default", "Color for free/busy calendars
 gflags.DEFINE_string("color_date", "yellow", "Color for the date")
 gflags.DEFINE_string("color_now_marker", "brightred", "Color for the now marker")
 gflags.DEFINE_string("color_border", "white", "Color of line borders")
+
+gflags.DEFINE_string("conky_color_owner", "cyan", "Color for owned calendars in conky")
+gflags.DEFINE_string("conky_color_writer", "green", "Color for writable calendars in conku")
+gflags.DEFINE_string("conky_color_reader", "magenta", "Color for read-only calendars in conky")
+gflags.DEFINE_string("conky_color_freebusy", "default", "Color for free/busy calendars in conky")
+gflags.DEFINE_string("conky_color_date", "yellow", "Color for the date in conky")
+gflags.DEFINE_string("conky_color_now_marker", "brightred", "Color for the now marker in conky")
+gflags.DEFINE_string("conky_color_border", "white", "Color of line borders in conky")
 
 gflags.DEFINE_string("locale", None, "System locale")
 
@@ -1961,6 +1998,7 @@ gflags.RegisterValidator("details",
                         lambda value: all(x in ["all", "calendar",
                            "location", "length", "reminders", "descr",
                            "longurl", "shorturl", "url"] for x in value))
+
 gflags.RegisterValidator("color_owner",
                          lambda value: GetColor(value) != None)
 gflags.RegisterValidator("color_writer",
@@ -1975,6 +2013,24 @@ gflags.RegisterValidator("color_now_marker",
                          lambda value: GetColor(value) != None)
 gflags.RegisterValidator("color_border",
                          lambda value: GetColor(value) != None)
+
+
+gflags.RegisterValidator("conky_color_owner",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_writer",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_reader",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_freebusy",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_date",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_now_marker",
+                         lambda value: ValidColor(value) != None)
+gflags.RegisterValidator("conky_color_border",
+                         lambda value: ValidColor(value) != None)
+
+
 
 gflags.ADOPT_module_key_flags(gflags)
 
@@ -2099,13 +2155,13 @@ def BowChickaWowWow():
                    ignoreStarted=not FLAGS.started,
                    calWidth=FLAGS.width,
                    calMonday=FLAGS.monday,
-                   calOwnerColor=GetColor(FLAGS.color_owner),
-                   calWriterColor=GetColor(FLAGS.color_writer),
-                   calReaderColor=GetColor(FLAGS.color_reader),
-                   calFreeBusyColor=GetColor(FLAGS.color_freebusy),
-                   dateColor=GetColor(FLAGS.color_date),
-                   nowMarkerColor=GetColor(FLAGS.color_now_marker),
-                   borderColor=GetColor(FLAGS.color_border),
+                   calOwnerColor=GetColor(FLAGS.color_owner) if not FLAGS.conky else GetColor(FLAGS.conky_color_owner),
+                   calWriterColor=GetColor(FLAGS.color_writer) if not FLAGS.conky else GetColor(FLAGS.conky_color_writer),
+                   calReaderColor=GetColor(FLAGS.color_reader) if not FLAGS.conky else GetColor(FLAGS.conky_color_reader),
+                   calFreeBusyColor=GetColor(FLAGS.color_freebusy) if not FLAGS.conky else GetColor(FLAGS.conky_color_freebusy),
+                   dateColor=GetColor(FLAGS.color_date) if not FLAGS.conky else GetColor(FLAGS.conky_color_date),
+                   nowMarkerColor=GetColor(FLAGS.color_now_marker) if not FLAGS.conky else GetColor(FLAGS.conky_color_now_marker),
+                   borderColor=GetColor(FLAGS.color_border) if not FLAGS.conky else GetColor(FLAGS.conky_color_border),
                    tsv=FLAGS.tsv,
                    refreshCache=FLAGS.refresh,
                    useCache=FLAGS.cache,

--- a/gcalcli
+++ b/gcalcli
@@ -1876,7 +1876,8 @@ def GetColor(value):
     if value in colors:
         return colors[value]
     else:
-        return CLR_CUSTOM(value) if FLAGS.conky else None
+        #Check if real Conky color
+        return CLR_CUSTOM(value) if FLAGS.conky and ("${color " in value)  else None
 
 def GetCalColors(calNames):
     calColors = {}


### PR DESCRIPTION
![2013-06-05-013049_1600x900_scrot](https://f.cloud.github.com/assets/1667287/609374/d043793c-cd7f-11e2-8250-23fbe0624e8c.png)
Colors must start with ## for it to work, and on terminal it is ignored, as the characters get escaped.
