### PR TITLE
Added a setup.py file to enable easy easy installation with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+from distutils.core import setup
+
+setup(name='gcalcli',
+      version='3.1',
+      description='Google Calendar Command Line Interface',
+      url='https://github.com/insanum/gcalcli',
+      license='MIT',
+      scripts=['gcalcli'],
+      install_requires = [
+        'dateutils',
+        'gdata',
+        'python-gflags',
+        'httplib2',
+        'google-api-python-client',
+      ],
+      extras_require = {
+        'vobject':  ["vobject"],
+        'parsedatetime': ["parsedatetime"],
+      }
+)


### PR DESCRIPTION
Now, you can simply do "pip install ." to get everything installed
to run gcalcli.
