### PR TITLE
Allow --description flag with the quick command.

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1521,7 +1521,7 @@ class gcalcli:
         self._GraphEvents(cmd, start, count, eventList)
 
 
-    def QuickAddEvent(self, eventText, reminder=None):
+    def QuickAddEvent(self, eventText, reminder=None, description=None):
 
         if eventText == '':
             return
@@ -1544,6 +1544,15 @@ class gcalcli:
                        patch(calendarId = self.cals[0]['id'],
                              eventId = newEvent['id'],
                              body = rem).execute()
+
+        if description:
+            desc = {}
+            desc['description'] = unicode(description, locale.getpreferredencoding() or "UTF-8")
+
+            newEvent = self._CalService().events().\
+                       patch(calendarId = self.cals[0]['id'],
+                             eventId = newEvent['id'],
+                             body = desc).execute()
 
         if self.detailUrl:
             hLink = self._ShortenURL(newEvent['htmlLink'])
@@ -2179,7 +2188,7 @@ def BowChickaWowWow():
 
         # allow unicode strings for input
         gcal.QuickAddEvent(unicode(args[1], locale.getpreferredencoding() or "UTF-8"),
-                           reminder=FLAGS.reminder)
+                           reminder=FLAGS.reminder, description=FLAGS.description)
 
     elif (args[0] == 'add'):
         if FLAGS.title == None and FLAGS.prompt:


### PR DESCRIPTION
The auto-parsing of quickAdd is very nice, but an additional (long)
description can also be useful.
