### PR TITLE
Changing the 'scope' setting (for OAuth2) to be string instead of a list.

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -499,8 +499,7 @@ class gcalcli:
                     OAuth2WebServerFlow(
                         client_id=self.client_id,
                         client_secret=self.client_secret,
-                        scope=['https://www.googleapis.com/auth/calendar',
-                               'https://www.googleapis.com/auth/urlshortener'],
+                        scope='https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/urlshortener',
                         user_agent=__program__+'/'+__version__),
                     storage)
 


### PR DESCRIPTION
The OAuth2 url generated by gcalcli is invalid for me, changing the scope passed to it to a string instead of a list fixes it though.

Note that the API documentation for OAuth2WebServerFlow says that it should be a string:
https://google-api-python-client.googlecode.com/hg/docs/epy/oauth2client.client.OAuth2WebServerFlow-class.html
