### PR TITLE
Unquote calendar names before usage

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -2047,6 +2047,7 @@ def BowChickaWowWow():
 
     calNames = []
     calNameColors = []
+    FLAGS.calendar = [c.strip('"\'') for c in FLAGS.calendar]
     calColors = GetCalColors(FLAGS.calendar)
     calNamesFiltered = []
     for calName in FLAGS.calendar:


### PR DESCRIPTION
Without this, a config file such as

```
--calendar='My calendar'
```

fails.
