### PR TITLE
Explicity call for python2

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # ** The MIT License **
 #


### PR DESCRIPTION
As per PEP 0394 [1], you should be calling for python2 in your shebang.

```
in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line.
```

As work on replacing python2 with python3 as the default python implementation seems to be picking up speed recently [2][3], it'd be great if this change could be made sooner, rather than later.

[1] http://legacy.python.org/dev/peps/pep-0394/
[2] https://www.phoronix.com/scan.php?page=news_item&px=Fedora-22-Python-3-Status
[3] http://www.phoronix.com/scan.php?page=news_item&px=Ubuntu-16.04-Python-Plans