### PR TITLE
Use correct package name for dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='gcalcli',
       license='MIT',
       scripts=['gcalcli'],
       install_requires=[
-          'dateutils',
+          'python-dateutil',
           'python-gflags',
           'httplib2',
           'google-api-python-client',


### PR DESCRIPTION
The package "dateutils" referred to in setup.py is this one https://pypi.python.org/pypi/dateutils. I think the one that was actually meant was "python-dateutil" which is here: https://pypi.python.org/pypi/python-dateutil/
The reason setup.py currently works is because the "dateutils" package pulls in "python-dateutil" as a dependency.