### PR TITLE
Support oauth2client 1.5.1

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -192,7 +192,7 @@ try:
     from apiclient.errors import HttpError
     from oauth2client.file import Storage
     from oauth2client.client import OAuth2WebServerFlow
-    from oauth2client.tools import run
+    from oauth2client.tools import run_flow
 except ImportError as e:
     print "ERROR: Missing module - %s" % e.args[0]
     sys.exit(1)
@@ -667,7 +667,7 @@ class gcalcli:
             credentials = storage.get()
 
             if credentials is None or credentials.invalid:
-                credentials = run(
+                credentials = run_flow(
                     OAuth2WebServerFlow(
                         client_id=self.client_id,
                         client_secret=self.client_secret,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='gcalcli',
           'python-gflags',
           'httplib2',
           'google-api-python-client',
-          'oauth2client<=1.4.12'
+          'oauth2client'
       ],
       extras_require={
           'vobject':  ["vobject"],


### PR DESCRIPTION
My placing a harddepend on oauthclient<=1.4.12 was keeping gcalcli users on Arch Linux from [completely upgrading their systems](https://wiki.archlinux.org/index.php/Pacman#Partial_upgrades_are_unsupported). gcalcli as-is doesn't work as [old_run is completely removed from oauth2client 1.5.1](https://github.com/google/oauth2client/pull/285). A [simple workaround](https://aur.archlinux.org/cgit/aur.git/commit/?h=gcalcli&id=d771478ea2f5657ba2559963bbc47a09a4056855) is in-place.

I've only tested `gcalcli agenda` a bit; no issues so far. If there's a specific test I can do, please let me know.

Relevant issues/pr's: #204 #123 #165 