### PR TITLE
Don't crash if organizer or attendees' email addresses are not provided

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1270,7 +1270,7 @@ class gcalcli:
                     detailsIndent,
                     event['organizer'].get('displayName', 'Not Provided')
                                       .strip(),
-                    event['organizer']['email'].strip()
+                    event['organizer'].get('email', 'Not Provided').strip()
                 )
                 PrintMsg(CLR_NRM(), xstr)
 
@@ -1279,7 +1279,7 @@ class gcalcli:
                     xstr = "%s    %s: <%s>\n" % (
                         detailsIndent,
                         attendee.get('displayName', 'Not Provided').strip(),
-                        attendee['email'].strip()
+                        attendee.get('email', 'Not Provided').strip()
                     )
                     PrintMsg(CLR_NRM(), xstr)
 


### PR DESCRIPTION
gcalcli crashed when trying to print an event in a Google+ calendar:

    $ gcalcli --nocolor --nolineart --details=all agenda 2016-01-{30,31}

    Sa Jan 30  08:30  FOSDEM 2016
                         Calendar: tschwinge@googlemail.com
                         Link: https://plus.google.com/events/ck7ros5lr0usntht458tt6fsqgc
                         Location: ULB, Avenue Franklin Roosevelt, Brussels, Belgium
                         Attendees:
    DEBUG [u'displayName', u'id']
    Traceback (most recent call last):
      File "./gcalcli", line 2588, in <module>
        BowChickaWowWow()
      File "./gcalcli", line 2436, in BowChickaWowWow
        gcal.AgendaQuery(startText=args[1])
      File "./gcalcli", line 1692, in AgendaQuery
        self._IterateEvents(start, eventList, yearDate=False)
      File "./gcalcli", line 1537, in _IterateEvents
        self._PrintEvent(event, prefix)
      File "./gcalcli", line 1274, in _PrintEvent
        event['organizer']['email'].strip()
    KeyError: 'email'

It appears that no email address is provided (for Google+ events?), so be I'm
using the same "Not Provided" idiom that is used for several other fields:

    Sa Jan 30  08:30  FOSDEM 2016
                         Calendar: tschwinge@googlemail.com
                         Link: https://plus.google.com/events/ck7ros5lr0usntht458tt6fsqgc
                         Location: ULB, Avenue Franklin Roosevelt, Brussels, Belgium
                         Attendees:
                           FOSDEM: <Not Provided>
                           FOSDEM: <Not Provided>
                         Length: 1 day, 8:30:00
                         Reminder: (default)
                         Description:
                         +---------------------------------------------------------+
                         | FOSDEM 2016 will take place at ULB Campus Solbosch on   |
                         | Saturday 30 and Sunday 31 January 2016                  |
                         +---------------------------------------------------------+