### PR TITLE
Don't error out for events with no attendees

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1546,9 +1546,10 @@ class gcalcli:
             if self.ignoreStarted and (event['s'] < self.now):
                 continue
             if self.ignoreDeclined:
-                attendee = [a for a in event['attendees'] if a['email'] == event['gcalcli_cal']['id']][0]
-                if attendee and attendee['responseStatus'] == 'declined':
-                    continue
+                if 'attendees' in event:
+                    attendee = [a for a in event['attendees'] if a['email'] == event['gcalcli_cal']['id']][0]
+                    if attendee and attendee['responseStatus'] == 'declined':
+                        continue
 
             tmpDayStr = event['s'].strftime(dayFormat)
             prefix = None


### PR DESCRIPTION
Events where nobody is invited will not have any attendees, and cannot be declined.