### PR TITLE
Add a standard icon for notification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -188,7 +188,7 @@ gcalcli [options] command [command args or options]
                            event start time and title text)
                            - <mins> default is 10
                            - default command:
-                              'notify-send -u critical -a gcalcli %s'
+                              'notify-send -u critical -i appointment-soon -a gcalcli %s'
 
  Options:
 

--- a/docs/man1/gcalcli.1
+++ b/docs/man1/gcalcli.1
@@ -97,7 +97,7 @@ gcalcli is a Python application that allows you to access your Google Calendar(s
                            event start time and title text)
                            - <mins> default is 10
                            - default command:
-                              'notify-send -u critical -a gcalcli %%s'
+                              'notify-send -u critical -i appointment-soon -a gcalcli %%s'
 .SH SEE ALSO
 bash(1)
 

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -129,7 +129,7 @@ class GoogleCalendarInterface:
     authHttp = None
     calService = None
     urlService = None
-    command = 'notify-send -u critical -a gcalcli %s'
+    command = 'notify-send -u critical -i appointment-soon -a gcalcli %s'
     dateParser = utils.DateTimeParser()
 
     ACCESS_OWNER = 'owner'


### PR DESCRIPTION
Pass a standard icon name to ```notify-send``` so the notification popup looks nicer.
