### PR TITLE
Fix text-wrap when widechar appeared at cut index

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -859,12 +859,13 @@ class gcalcli:
         idx = 0
         printLen = 0
         for tmpChar in _u(string):
-            if (curPrintLen + printLen) >= self.calWidth:
+            printTmpChar = self.UNIWIDTH[east_asian_width(tmpChar)]
+            if (curPrintLen + printLen + printTmpChar) > self.calWidth:
                 return (printLen, idx, True)
             if tmpChar in (' ', '\n'):
                 return (printLen, idx, False)
             idx += 1
-            printLen += self.UNIWIDTH[east_asian_width(tmpChar)]
+            printLen += printTmpChar
         return (printLen, -1, False)
 
     def _GetCutIndex(self, eventString):


### PR DESCRIPTION
This commit is based on the branch `argparse_over_gflags`, since `v4.0.0a3` cannot be based and `master` has a huge difference from it

**Before commit**
![before](https://user-images.githubusercontent.com/11537681/29021558-7e48df84-7b98-11e7-9882-a0f1e74055ed.png)
**After commit**
![after](https://user-images.githubusercontent.com/11537681/29021559-7e4c7e6e-7b98-11e7-9e97-af9246ae641c.png)