### PR TITLE
Allow missing DTEND

### DIFF
--- a/gcalcli
+++ b/gcalcli
@@ -1960,26 +1960,25 @@ class gcalcli:
                     print "Location.....%s" % ve.location.value
                 event['location'] = ve.location.value
 
-            if not hasattr(ve, 'dtstart') or not hasattr(ve, 'dtend'):
-                PrintErrMsg("Error: event does not have a dtstart and "
-                            "dtend!\n")
+            if not hasattr(ve, 'dtstart'):
+                PrintErrMsg("Error: event does not have a dtstart!\n")
                 return None
 
             if ve.dtstart.value:
                 DebugPrint("DTSTART: %s\n" % ve.dtstart.value.isoformat())
-            if ve.dtend.value:
+            if hasattr(ve, 'dtend') and ve.dtend.value:
                 DebugPrint("DTEND: %s\n" % ve.dtend.value.isoformat())
             if verbose:
                 if ve.dtstart.value:
                     print "Start........%s" % \
                         ve.dtstart.value.isoformat()
-                if ve.dtend.value:
+                if hasattr(ve, 'dtend') and ve.dtend.value:
                     print "End..........%s" % \
                         ve.dtend.value.isoformat()
                 if ve.dtstart.value:
                     print "Local Start..%s" % \
                         self._LocalizeDateTime(ve.dtstart.value)
-                if ve.dtend.value:
+                if hasattr(ve, 'dtend') and ve.dtend.value:
                     print "Local End....%s" % \
                         self._LocalizeDateTime(ve.dtend.value)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='gcalcli',
           'python-dateutil',
           'python-gflags',
           'httplib2',
-          'google-api-python-client',
+          'google-api-python-client<=1.5.1',
           'oauth2client<=1.4.12'
       ],
       extras_require={


### PR DESCRIPTION
gcalcli already contains code to handle a missing DTEND. In order to import files that don't have it, all we have to do is remove the check that aborts the script if it's missing.

Bonus change: Specify the version of `google-api-python-client` in the dependencies, because the latest one now conflicts with the dependency on `oauth2client<=1.4.12`.
