### PR TITLE
Restrict google-api to be a version lower than 1.4.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='gcalcli',
           'python-dateutil',
           'python-gflags',
           'httplib2',
-          'google-api-python-client',
+          'google-api-python-client<=1.4.12',
           'oauth2client<=1.4.12'
       ],
       extras_require={


### PR DESCRIPTION
The latest google-api-python-client requires oauth2client >= 1.5, which isn't supported here.