### PR TITLE
Ability to override and edit event colour

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -250,6 +250,14 @@ def get_argument_parser():
     quick.add_argument("text")
 
     add = sub.add_parser("add", parents=[details_parser, remind_parser])
+    add.add_argument(
+            "--color",
+            default=None,
+            type=str,
+            help="Color of event in browser (overrides default). Choose "
+                 "from lavender, sage, grape, flamingo, banana, tangerine, "
+                 "peacock, graphite, blueberry, basil, tomato."
+    )
     add.add_argument("--title", default=None, type=str, help="Event title")
     add.add_argument(
             "--who", default=[], type=str, action="append", help="Event title")

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -71,6 +71,9 @@ def get_output_parser(parents=[]):
     output_parser.add_argument(
             "--military", action="store_true", default=False,
             help="Use 24 hour display")
+    output_parser.add_argument(
+            "--override-color", action="store_true", default=False,
+            help="Use overridden color for event")
     return output_parser
 
 

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -255,8 +255,7 @@ def get_argument_parser():
     add = sub.add_parser("add", parents=[details_parser, remind_parser])
     add.add_argument(
             "--color",
-            default=None,
-            type=str,
+            default=None, type=str,
             help="Color of event in browser (overrides default). Choose "
                  "from lavender, sage, grape, flamingo, banana, tangerine, "
                  "peacock, graphite, blueberry, basil, tomato."

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -1317,7 +1317,7 @@ class GoogleCalendarInterface:
             event['description'] = descr
 
         if color_id:
-            event['colorId'] = override_color_map.get(color_id.lower())
+            event['colorId'] = override_color_map.get(color_id)
 
         event['attendees'] = list(map(lambda w: {'email': w}, who))
 

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -737,8 +737,11 @@ class GoogleCalendarInterface:
         happeningNow = event['s'] <= self.now <= event['e']
         allDay = self._isallday(event)
         if self.options['override_color'] and event.get('colorId'):
-            eventColor = self._calendar_color(
-                event, override_color=True)
+            if happeningNow and not allDay:
+                eventColor = self.options['color_now_marker']
+            else:
+                eventColor = self._calendar_color(
+                    event, override_color=True)
         else:
             eventColor = self.options['color_now_marker'] \
                 if happeningNow and not allDay \

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -432,7 +432,8 @@ class GoogleCalendarInterface:
                         }
                         event_color = ansi_codes[event.get('colorId')]
                     else:
-                        event_color = self._calendar_color(event['gcalcli_cal'])
+                        event_color = self._calendar_color(
+                            event['gcalcli_cal'])
 
                 # NOTE(slawqo): for all day events it's necessary to add event
                 # to more than one day in week_events
@@ -950,7 +951,8 @@ class GoogleCalendarInterface:
                 self.printer.msg('Color: ', 'magenta')
                 val = input()
                 if val not in valid_override_colors:
-                    err_msg = "Valid colors are " + " ".join(valid_override_colors) + "."
+                    err_msg = "Valid colors are " + " ".join(
+                        valid_override_colors) + "."
                     self.printer.msg(err_msg, 'red')
                 else:
                     self.options['override_color'] = True
@@ -1291,7 +1293,16 @@ class GoogleCalendarInterface:
 
         return new_event
 
-    def AddEvent(self, title, where, start, end, descr, who, reminders, color_id):
+    def AddEvent(
+            self,
+            title,
+            where,
+            start,
+            end,
+            descr,
+            who,
+            reminders,
+            color_id):
 
         if len(self.cals) != 1:
             # TODO: get a better name for this exception class

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -1286,7 +1286,7 @@ class GoogleCalendarInterface:
         return new_event
 
     def AddEvent(
-            self, title, where, start, end, descr, who, reminders, color_id):
+            self, title, where, start, end, descr, who, reminders, color):
 
         if len(self.cals) != 1:
             # TODO: get a better name for this exception class
@@ -1311,8 +1311,8 @@ class GoogleCalendarInterface:
         if descr:
             event['description'] = descr
 
-        if color_id:
-            event['colorId'] = override_color_map.get(color_id)
+        if color:
+            event['colorId'] = override_color_map.get(color)
 
         event['attendees'] = list(map(lambda w: {'email': w}, who))
 

--- a/gcalcli/utils.py
+++ b/gcalcli/utils.py
@@ -11,19 +11,22 @@ from parsedatetime.parsedatetime import Calendar
 locale.setlocale(locale.LC_ALL, '')
 fuzzy_date_parse = Calendar().parse
 
-OVERRIDE_COLOR_MAP = {
-    "lavender": 1,
-    "sage": 2,
-    "grape": 3,
-    "flamingo": 4,
-    "banana": 5,
-    "tangerine": 6,
-    "peacock": 7,
-    "graphite": 8,
-    "blueberry": 9,
-    "basil": 10,
-    "tomato": 11,
-}
+valid_override_colors = [
+    "lavender",
+    "sage",
+    "grape",
+    "flamingo",
+    "banana",
+    "tangerine",
+    "peacock",
+    "graphite",
+    "blueberry",
+    "basil",
+    "tomato",
+]
+
+override_color_map = {x[1]: x[0]
+                      for x in list(enumerate(valid_override_colors, start=1))}
 
 
 def parse_reminder(rem):

--- a/gcalcli/utils.py
+++ b/gcalcli/utils.py
@@ -11,6 +11,20 @@ from parsedatetime.parsedatetime import Calendar
 locale.setlocale(locale.LC_ALL, '')
 fuzzy_date_parse = Calendar().parse
 
+OVERRIDE_COLOR_MAP = {
+    "lavender": 1,
+    "sage": 2,
+    "grape": 3,
+    "flamingo": 4,
+    "banana": 5,
+    "tangerine": 6,
+    "peacock": 7,
+    "graphite": 8,
+    "blueberry": 9,
+    "basil": 10,
+    "tomato": 11,
+}
+
 
 def parse_reminder(rem):
     matchObj = re.match(r'^(\d+)([wdhm]?)(?:\s+(popup|email|sms))?$', rem)

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -130,7 +130,8 @@ def test_add_event(PatchedGCalI):
     who = 'anyone'
     reminders = None
     color_id = 11
-    assert gcal.AddEvent(title, where, start, end, descr, who, reminders, color_id)
+    assert gcal.AddEvent(
+        title, where, start, end, descr, who, reminders, color_id)
 
 
 def test_quick_add(PatchedGCalI):

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -3,7 +3,7 @@ import os
 import sys
 from json import load
 from datetime import datetime
-from dateutil.tz import tzutc
+from dateutil.tz import tzutc, tzlocal
 
 import pytest
 from apiclient.discovery import HttpMock, build
@@ -19,6 +19,43 @@ from gcalcli.gcalcli import (GoogleCalendarInterface,
 
 TEST_DATA_DIR = os.path.dirname(os.path.abspath(__file__)) + '/data'
 
+mock_event = [{'colorId': "10",
+               'created': '2018-12-31T09:20:32.000Z',
+               'creator': {'email': 'matthew.lemon@gmail.com'},
+               'e': datetime(2019, 1, 8, 15, 15, tzinfo=tzlocal()),
+               'end': {'dateTime': '2019-01-08T15:15:00Z'},
+               'etag': '"3092496064420000"',
+               'gcalcli_cal': {'accessRole': 'owner',
+                               'backgroundColor': '#4986e7',
+                               'colorId': '16',
+                               'conferenceProperties': {
+                                   'allowedConferenceSolutionTypes':
+                                   ['eventHangout']
+                               },
+                               'defaultReminders': [],
+                               'etag': '"153176133553000"',
+                               'foregroundColor': '#000000',
+                               'id': '12pp3nqo@group.calendar.google.com',
+                               'kind': 'calendar#calendarListEntry',
+                               'selected': True,
+                               'summary': 'Test Calendar',
+                               'timeZone': 'Europe/London'},
+               'htmlLink': '',
+               'iCalUID': '31376E6-8B63-416C-B73A-74D10F51F',
+               'id': '_6coj0c9o88r3b9a26spk2b9n6sojed2464o4cd9h8o',
+               'kind': 'calendar#event',
+               'organizer': {
+                   'displayName': 'Test Calendar',
+                   'email': 'tst@group.google.com',
+                   'self': True},
+               'reminders': {'useDefault': True},
+               's': datetime(2019, 1, 8, 14, 15, tzinfo=tzlocal()),
+               'sequence': 0,
+               'start': {'dateTime': '2019-01-08T14:15:00Z'},
+               'status': 'confirmed',
+               'summary': 'Test Event',
+               'updated': '2018-12-31T09:20:32.210Z'}]
+
 
 @pytest.fixture
 def default_options():
@@ -26,6 +63,52 @@ def default_options():
     opts.update(vars(get_cal_query_parser().parse_args([])))
     opts.update(vars(get_output_parser().parse_args([])))
     return opts
+
+
+@pytest.fixture
+def PatchedGCalIForEvents(monkeypatch):
+    def mocked_search_for_events(self, start, end, search_text):
+        return mock_event
+
+    def mocked_calendar_service(self):
+        http = HttpMock(
+                TEST_DATA_DIR + '/cal_service_discovery.json',
+                {'status': '200'})
+        if not self.calService:
+            self.calService = build(
+                    serviceName='calendar', version='v3', http=http)
+        return self.calService
+
+    def mocked_calendar_list(self):
+        http = HttpMock(
+                TEST_DATA_DIR + '/cal_list.json', {'status': '200'})
+        request = self._cal_service().calendarList().list()
+        cal_list = request.execute(http=http)
+        self.allCals = [cal for cal in cal_list['items']]
+        if not self.calService:
+            self.calService = build(
+                 serviceName='calendar', version='v3', http=http)
+        return self.calService
+
+    def mocked_msg(self, msg, colorname='default', file=sys.stdout):
+        # ignores file and always writes to stdout
+        if self.use_color:
+            msg = self.colors[colorname] + msg + self.colors['default']
+        sys.stdout.write(msg)
+
+    monkeypatch.setattr(
+            GoogleCalendarInterface, '_search_for_events',
+            mocked_search_for_events)
+    monkeypatch.setattr(
+            GoogleCalendarInterface, '_cal_service', mocked_calendar_service)
+    monkeypatch.setattr(
+            GoogleCalendarInterface, '_get_cached', mocked_calendar_list)
+    monkeypatch.setattr(Printer, 'msg', mocked_msg)
+
+    def _init(**opts):
+        return GoogleCalendarInterface(use_cache=False, **opts)
+
+    return _init
 
 
 @pytest.fixture
@@ -129,9 +212,21 @@ def test_add_event(PatchedGCalI):
     descr = 'testing'
     who = 'anyone'
     reminders = None
-    color_id = 11
+    color = "banana"
     assert gcal.AddEvent(
-        title, where, start, end, descr, who, reminders, color_id)
+        title, where, start, end, descr, who, reminders, color)
+
+
+def test_add_event_override_color(capsys, default_options,
+                                  PatchedGCalIForEvents):
+    default_options.update({'override_color': True})
+    cal_names = parse_cal_names(['jcrowgey@uw.edu'])
+    gcal = PatchedGCalIForEvents(cal_names=cal_names, **default_options)
+    gcal.AgendaQuery()
+    captured = capsys.readouterr()
+    # this could be parameterized with pytest eventually
+    # assert colorId 10: green
+    assert '\033[0;32m' in captured.out
 
 
 def test_quick_add(PatchedGCalI):

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -129,7 +129,8 @@ def test_add_event(PatchedGCalI):
     descr = 'testing'
     who = 'anyone'
     reminders = None
-    assert gcal.AddEvent(title, where, start, end, descr, who, reminders)
+    color_id = 11
+    assert gcal.AddEvent(title, where, start, end, descr, who, reminders, color_id)
 
 
 def test_quick_add(PatchedGCalI):


### PR DESCRIPTION
Please find this PR in response to #393.

User is able to override the colour of a new event using the `--color` flag. Valid colour values match that in Google Calendar UI ("lavender", "grape", etc).

When viewing events using `agenda`, `calm` or `calw` commands, the overridden colours can be viewed using the `--override-color` flag.  Colours can be edited in using the `edit` command.

I have decided not to implement any locale-based code (for `--colo[u]r`) at this stage, but I'm interested in coming back to that.

This code (colour output in terminal/browser) is very difficult to test, so I have not gone down that route at this stage, although I am interested in the general desire to write better unit tests for this software and may sumit issues/PRs for this in future.

`edit --help` shows the option for `--override-color` which is not strictly accurate - these are being pulled in from other parsers.
