### PR TITLE
382 parser warnings

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -148,6 +148,7 @@ def get_color_parser():
     return color_parser
 
 
+@parser_allow_deprecated
 def get_remind_parser():
     remind_parser = argparse.ArgumentParser(add_help=False)
     remind_parser.add_argument(
@@ -159,7 +160,7 @@ def get_remind_parser():
             "minutes) and default to minutes.  METH is a string "
             "'popup', 'email', or 'sms' and defaults to popup.")
     remind_parser.add_argument(
-            "--default_reminders", action="store_true",
+            "--default-reminders", action="store_true",
             dest="default_reminders", default=False,
             help="If no --reminder is given, use the defaults.  If this is "
             "false, do not create any reminders.")

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import argparse
 import gcalcli
 from gcalcli import utils
+from gcalcli.decorators import parser_allow_deprecated
 from gcalcli.printer import valid_color_name
 from oauth2client import tools
 import copy as _copy
@@ -116,31 +117,33 @@ def get_output_parser(parents=[]):
     return output_parser
 
 
+@parser_allow_deprecated
 def get_color_parser():
-    color_parser = argparse.ArgumentParser(add_help=False)
+    color_parser = argparse.ArgumentParser(add_help=False,
+                                           conflict_handler="resolve")
     color_parser.add_argument(
-            "--color_owner", default="cyan", type=valid_color_name,
+            "--color-owner", default="cyan", type=valid_color_name,
             help="Color for owned calendars")
     color_parser.add_argument(
-            "--color_writer", default="green", type=valid_color_name,
+            "--color-writer", default="green", type=valid_color_name,
             help="Color for writable calendars")
     color_parser.add_argument(
-            "--color_reader", default="magenta", type=valid_color_name,
+            "--color-reader", default="magenta", type=valid_color_name,
             help="Color for read-only calendars")
     color_parser.add_argument(
-            "--color_freebusy", default="default", type=valid_color_name,
+            "--color-freebusy", default="default", type=valid_color_name,
             help="Color for free/busy calendars")
     color_parser.add_argument(
-            "--color_date", default="yellow", type=valid_color_name,
+            "--color-date", default="yellow", type=valid_color_name,
             help="Color for the date")
     color_parser.add_argument(
-            "--color_now_marker", default="brightred", type=valid_color_name,
+            "--color-now_marker", default="brightred", type=valid_color_name,
             help="Color for the now marker")
     color_parser.add_argument(
-            "--color_border", default="white", type=valid_color_name,
+            "--color-border", default="white", type=valid_color_name,
             help="Color of line borders")
     color_parser.add_argument(
-            "--color_title", default="brightyellow", type=valid_color_name,
+            "--color-title", default="brightyellow", type=valid_color_name,
             help="Color of the agenda column titles")
     return color_parser
 

--- a/gcalcli/decorators.py
+++ b/gcalcli/decorators.py
@@ -1,42 +1,45 @@
 from __future__ import absolute_import
 import argparse
+import functools
 
 from gcalcli.printer import valid_color_name
 
-_deprecated_opts = (
-    ("--color_", "--color-")
-)
+COLOR_BASE_OPTS = {"type": valid_color_name,
+                   "help": argparse.SUPPRESS
+                   }
+
+COLOR_PARSER_OPTIONS = {
+    "--color_owner": {"default": "cyan"},
+    "--color_writer": {"default": "cyan"},
+    "--color_reader": {"default": "magenta"},
+    "--color_freebusy": {"default": "default"},
+    "--color_date": {"default": "yellow"},
+    "--color_now-marker": {"default": "brightred"},
+    "--color_border": {"default": "white"},
+    "--color_title": {"default": "brightyellow"},
+}
 
 
 def parser_allow_deprecated(getter_func):
-    def wrapped(*args, **kwargs):
-        color_parser = getter_func()
-        color_parser.add_argument(
-                "--color_owner", dest="color_owner",  default="cyan",
-                type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_writer", default="green", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_reader", default="magenta", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_freebusy", default="default", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_date", default="yellow", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_now-marker",
-                default="brightred",
-                type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_border", default="white", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        color_parser.add_argument(
-                "--color_title", default="brightyellow", type=valid_color_name,
-                help=argparse.SUPPRESS)
-        return color_parser
-    return wrapped
+    if getter_func.__name__ == "get_color_parser":
+        @functools.wraps(getter_func)
+        def wrapped(*args, **kwargs):
+            color_parser = getter_func()
+            for opt in COLOR_PARSER_OPTIONS.items():
+                color_parser.add_argument(
+                    opt[0], default=opt[1]['default'], **COLOR_BASE_OPTS
+                )
+            return color_parser
+        return wrapped
+    if getter_func.__name__ == "get_remind_parser":
+        def wrapped(*args, **kwargs):
+            remind_parser = getter_func()
+            remind_parser.add_argument(
+                    "--default_reminders", action="store_true",
+                    dest="default_reminders", default=False,
+                    help=argparse.SUPPRESS)
+            return remind_parser
+        return wrapped
+
+
+ALL_DEPRECATED_OPTS = COLOR_PARSER_OPTIONS

--- a/gcalcli/decorators.py
+++ b/gcalcli/decorators.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+import argparse
+
+from gcalcli.printer import valid_color_name
+
+_deprecated_opts = (
+    ("--color_", "--color-")
+)
+
+
+def parser_allow_deprecated(getter_func):
+    def wrapped(*args, **kwargs):
+        color_parser = getter_func()
+        color_parser.add_argument(
+                "--color_owner", dest="color_owner",  default="cyan",
+                type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_writer", default="green", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_reader", default="magenta", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_freebusy", default="default", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_date", default="yellow", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_now-marker",
+                default="brightred",
+                type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_border", default="white", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        color_parser.add_argument(
+                "--color_title", default="brightyellow", type=valid_color_name,
+                help=argparse.SUPPRESS)
+        return color_parser
+    return wrapped

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -1626,12 +1626,15 @@ def _warn_deprecated_opts(argv):
     Tests whether options are in ALL_DEPRECATED_OPT.
     Prints clear warning message to user if so.
     """
+    _depr_args = []
     for arg in argv:
         if arg in ALL_DEPRECATED_OPTS.keys():
-            printer = Printer()
-            printer.err_msg("WARNING: {} is deprecated and will "
-                            "be removed. Please use {}\n".format(
-                                arg, arg.replace("_", "-")))
+            _depr_args.append(arg)
+    for arg in _depr_args:
+        printer = Printer()
+        printer.err_msg("WARNING: {} is deprecated and will "
+                        "be removed. Please use {}\n".format(
+                            arg, arg.replace("_", "-")))
 
 
 def main():

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -1623,6 +1623,8 @@ def main():
     parser = get_argument_parser()
     try:
         argv = sys.argv[1:]
+        if "--color_owner" in argv:
+            print("Some message")
         gcalclirc = os.path.expanduser('~/.gcalclirc')
         if os.path.exists(gcalclirc):
             # We want .gcalclirc to be sourced before any other --flagfile

--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -72,6 +72,8 @@ from gcalcli.validators import (
     get_input, get_override_color_id, STR_NOT_EMPTY, PARSABLE_DATE, STR_TO_INT,
     VALID_COLORS, STR_ALLOW_EMPTY, REMINDER)
 
+from gcalcli.decorators import ALL_DEPRECATED_OPTS
+
 # Required 3rd party libraries
 try:
     from dateutil.tz import tzlocal
@@ -1619,12 +1621,24 @@ def run_add_prompt(parsed_args, printer):
             parsed_args.reminders.append(str(n) + ' ' + m)
 
 
+def _warn_deprecated_opts(argv):
+    """
+    Tests whether options are in ALL_DEPRECATED_OPT.
+    Prints clear warning message to user if so.
+    """
+    for arg in argv:
+        if arg in ALL_DEPRECATED_OPTS.keys():
+            printer = Printer()
+            printer.err_msg("WARNING: {} is deprecated and will "
+                            "be removed. Please use {}\n".format(
+                                arg, arg.replace("_", "-")))
+
+
 def main():
     parser = get_argument_parser()
     try:
         argv = sys.argv[1:]
-        if "--color_owner" in argv:
-            print("Some message")
+        _warn_deprecated_opts(argv)
         gcalclirc = os.path.expanduser('~/.gcalclirc')
         if os.path.exists(gcalclirc):
             # We want .gcalclirc to be sourced before any other --flagfile
@@ -1634,7 +1648,7 @@ def main():
         else:
             tmp_argv = argv
 
-        (parsed_args, junk) = parser.parse_known_args(tmp_argv)
+        (parsed_args, unparsed) = parser.parse_known_args(tmp_argv)
     except Exception as e:
         sys.stderr.write(str(e))
         parser.print_usage()

--- a/tests/test_argparsers.py
+++ b/tests/test_argparsers.py
@@ -1,6 +1,13 @@
 from gcalcli import argparsers
+from gcalcli.decorators import parser_allow_deprecated
 import shlex
 import pytest
+
+
+def test_parser_decorator():
+    color_parser = parser_allow_deprecated(argparsers.get_color_parser)
+    parser = color_parser()
+    assert parser.parse_args(["--color-owner", "default"])
 
 
 def test_get_argparser():


### PR DESCRIPTION
WIP PR reference #382.

Uses a decorator to allow new "dashed" semantics (e.g. "--color-owner").

Does not decorate work with the core parser as yet, but does so with color/reminder parsers.

Very grateful for comments and feedback!