### PR TITLE
Fixed variable left in code after PR #411

### DIFF
--- a/gcalcli/gcalcli.py
+++ b/gcalcli/gcalcli.py
@@ -1632,7 +1632,7 @@ def main():
         else:
             tmp_argv = argv
 
-        (parsed_args, junk) = parser.parse_known_args(tmp_argv)
+        (parsed_args, unparsed) = parser.parse_known_args(tmp_argv)
     except Exception as e:
         sys.stderr.write(str(e))
         parser.print_usage()


### PR DESCRIPTION
This was left over after earlier merge and breaks the application if for anyone currently using master if not passing in `configFolder` option.