### PR TITLE
parsedatetime is not an optional requirement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,9 +29,6 @@ Requirements
 
 * [vobject](http://vobject.skyhouseconsulting.com) Python module
   Used for ics/vcal importing.
-* [parsedatetime](http://github.com/bear/parsedatetime) Python module
-  Used for fuzzy dates/times like "now", "today", "eod tomorrow", etc.
-
 
 Installation
 ------------
@@ -64,10 +61,10 @@ cd gcalcli
 python setup.py install
 ```
 
-### Install optional packages
+### Install optional package
 
 ```sh
-pip install vobject parsedatetime
+pip install vobject
 ```
 
 Features

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(name='gcalcli',
       ],
       extras_require={
           'vobject': ["vobject"],
-          'parsedatetime': ["parsedatetime"],
       },
       entry_points={
           'console_scripts':


### PR DESCRIPTION
Since v4.0.0 parsedatetime has been a requirement. (https://github.com/insanum/gcalcli/commit/166a58a81068cef858caece10e41db591f98ac53) parsedatetime was originally an "extra", a recommended optional package. The commit adding it as a hard dependency didn't remove it from the list of extras.

Before this change both docs/README.md and setup.py list parsedatetime twice. After this change parsedatetime is not described as optional.