### PR TITLE
Remove URL Shortening [fixes #440]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+v4.1.0
+  * Removed url shortening due to Google deprecation #440
+
 v4.0.4
   * Minor bugfixes: conky colors, issues with setup.py
 

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -7,11 +7,9 @@ from gcalcli.printer import valid_color_name
 from oauth2client import tools
 import copy as _copy
 
-DETAILS = ['all', 'calendar', 'location', 'length', 'reminders', 'description',
-           'longurl', 'shorturl', 'url', 'attendees', 'email', 'attachments']
+DETAILS = ['calendar', 'location', 'length', 'reminders', 'description',
+           'url', 'attendees', 'email', 'attachments']
 
-BOOL_DETAILS = ['calendar', 'location', 'length', 'reminders', 'description',
-                'attendees', 'email', 'attachments']
 
 PROGRAM_OPTIONS = {
         '--client-id': {'default': gcalcli.__API_CLIENT_ID__,
@@ -60,18 +58,9 @@ class DetailsAction(argparse._AppendAction):
         details = _copy.copy(getattr(namespace, self.dest, {}))
 
         if value == 'all':
-            details.update({d: True for d in BOOL_DETAILS})
-            if 'url' not in details:
-                # url isn't boolean, but should be included in 'all'
-                # but we don't want to override this if they specifically ask
-                # for longurl (ie --details=longurl --details=all should work)
-                details['url'] = 'short'
-        elif value in BOOL_DETAILS:
+            details.update({d: True for d in DETAILS})
+        else:
             details[value] = True
-        elif value in ['shorturl', 'url']:
-            details['url'] = 'short'
-        elif value == 'longurl':
-            details['url'] = 'long'
 
         setattr(namespace, self.dest, details)
 
@@ -95,7 +84,7 @@ def get_details_parser():
     details_parser = argparse.ArgumentParser(add_help=False)
     details_parser.add_argument(
             '--details', default={}, action=DetailsAction,
-            choices=DETAILS,
+            choices=DETAILS + ['all'],
             help='Which parts to display, can be: ' + ', '.join(DETAILS))
     return details_parser
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ author_emails = ['edavis@insanum.com',
                  'jcrowgey@uw.edu']
 
 setup(name='gcalcli',
-      version='4.0.4',
+      version='4.1.0',
       author='Eric Davis, Brian Hartvigsen, Joshua Crowgey',
       author_email=', '.join(author_emails),
       maintainer='Joshua Crowgey',

--- a/tests/test_argparsers.py
+++ b/tests/test_argparsers.py
@@ -42,16 +42,11 @@ def test_details_parser():
     parsed_details = details_parser.parse_args(argv).details
     assert parsed_details['attendees']
     assert parsed_details['location']
-    assert parsed_details['url'] == 'short'
+    assert parsed_details['url']
 
     argv = shlex.split('--details all')
     parsed_details = details_parser.parse_args(argv).details
-    assert all(parsed_details[d] for d in argparsers.BOOL_DETAILS)
-
-    # ensure we can specify url type even with details=all
-    argv = shlex.split('--details all --details longurl')
-    parsed_details = details_parser.parse_args(argv).details
-    assert parsed_details['url'] == 'long'
+    assert all(parsed_details[d] for d in argparsers.DETAILS)
 
 
 def test_handle_unparsed():


### PR DESCRIPTION
Google has removed the urlshortening service.  After some discussion,
it was decided to remove the shortening facilities instead of trying to
integrate with a separate provider.  This makes our code simpler and
folks who need url shortening can hopefully layer on what they need.