### PR TITLE
Don't throw IndexError if attendee cannot be found in _DeclinedEvent

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1122,7 +1122,7 @@ class GoogleCalendarInterface:
         if 'attendees' in event:
             attendees = [a for a in event['attendees']
                         if a['email'] == event['gcalcli_cal']['id']]
-            if attendees and and attendees[0]['responseStatus'] == 'declined':
+            if attendees and attendees[0]['responseStatus'] == 'declined':
                 return True
         return False
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1120,9 +1120,9 @@ class GoogleCalendarInterface:
 
     def _DeclinedEvent(self, event):
         if 'attendees' in event:
-            attendee = [a for a in event['attendees']
-                        if a['email'] == event['gcalcli_cal']['id']][0]
-            if attendee and attendee['responseStatus'] == 'declined':
+            attendees = [a for a in event['attendees']
+                        if a['email'] == event['gcalcli_cal']['id']]
+            if attendees and and attendees[0]['responseStatus'] == 'declined':
                 return True
         return False
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1121,7 +1121,7 @@ class GoogleCalendarInterface:
     def _DeclinedEvent(self, event):
         if 'attendees' in event:
             attendees = [a for a in event['attendees']
-                        if a['email'] == event['gcalcli_cal']['id']]
+                         if a['email'] == event['gcalcli_cal']['id']]
             if attendees and attendees[0]['responseStatus'] == 'declined':
                 return True
         return False

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -159,6 +159,7 @@ def test_declined_event_non_matching_attendees(PatchedGCalI):
     }
     assert not gcal._DeclinedEvent(event)
 
+
 def test_declined_event_matching_attendee_declined(PatchedGCalI):
     gcal = PatchedGCalI()
     event = {

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -135,6 +135,70 @@ def test_text_query(PatchedGCalI):
     assert gcal.TextQuery(opts.text, opts.start, opts.end) == 0
 
 
+def test_declined_event_no_attendees(PatchedGCalI):
+    gcal = PatchedGCalI()
+    event = {
+        'gcalcli_cal': {
+            'id': 'user@email.com',
+        },
+        'attendees': []
+    }
+    assert not gcal._DeclinedEvent(event)
+
+
+def test_declined_event_non_matching_attendees(PatchedGCalI):
+    gcal = PatchedGCalI()
+    event = {
+        'gcalcli_cal': {
+            'id': 'user@email.com',
+        },
+        'attendees': [{
+            'email': 'user2@otheremail.com',
+            'responseStatus': 'declined',
+        }]
+    }
+    assert not gcal._DeclinedEvent(event)
+
+def test_declined_event_matching_attendee_declined(PatchedGCalI):
+    gcal = PatchedGCalI()
+    event = {
+        'gcalcli_cal': {
+            'id': 'user@email.com',
+        },
+        'attendees': [
+            {
+                'email': 'user@email.com',
+                'responseStatus': 'declined',
+            },
+            {
+                'email': 'user2@otheremail.com',
+                'responseStatus': 'accepted',
+            },
+        ]
+    }
+    assert gcal._DeclinedEvent(event)
+
+
+def test_declined_event_matching_attendee_accepted(PatchedGCalI):
+    gcal = PatchedGCalI()
+    event = {
+        'gcalcli_cal': {
+            'id': 'user@email.com',
+        },
+        'attendees': [
+            {
+                'email': 'user@email.com',
+                'responseStatus': 'accepted',
+            },
+            {
+                'email': 'user2@otheremail.com',
+                'responseStatus': 'declined',
+            },
+        ]
+    }
+    assert not gcal._DeclinedEvent(event)
+
+
 def test_modify_event(PatchedGCalI):
     opts = get_search_parser().parse_args(['test'])
     gcal = PatchedGCalI(**vars(opts))


### PR DESCRIPTION
Fixes an IndexError thrown in `_DeclinedEvent` if no attendee with a matching email can be found when checking if an event has been declined (through `--nodeclined`).