### PR TITLE
Add conflicts command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ gcalcli
 
 gcalcli is a Python application that allows you to access your Google
 Calendar(s) from a command line. It's easy to get your agenda, search for
-events, add new events, delete events, edit events, see recently updated 
-events, and even import those annoying ICS/vCal invites from Microsoft 
+events, add new events, delete events, edit events, see recently updated
+events, and even import those annoying ICS/vCal invites from Microsoft
 Exchange and/or other sources. Additionally, gcalcli can be used as a reminder
 service and execute any application you want when an event is coming up.
 
@@ -74,6 +74,7 @@ Features
  * list your calendars
  * show an agenda using a specified start/end date and time
  * show updates since a specified datetime for events between a start/end date and time
+ * find conflicts between events matching search term
  * ascii text graphical calendar display with variable width
  * search for past and/or future events
  * "quick add" new events to a specified calendar

--- a/docs/man1/gcalcli.1
+++ b/docs/man1/gcalcli.1
@@ -28,13 +28,14 @@ gcalcli [-h] [--auth_host_name AUTH_HOST_NAME]
 
 
 Positional arguments:
-  {list,search,edit,delete,agenda,updates,calw,calm,quick,add,import,remind}
+  {list,search,edit,delete,agenda,updates,conflicts,calw,calm,quick,add,import,remind}
                         Invoking a subcommand with --help prints subcommand
                         usage.
     list                list available calendars
     edit                edit calendar events
     agenda              get an agenda for a time period
     updates             get updates since a datetime for a time period
+    conflicts		find conflicts between events matching search term
     calw                get a week-based agenda in calendar format
     calm                get a month agenda in calendar format
     quick               quick-add an event to a calendar

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -201,6 +201,17 @@ def get_updates_parser():
     return updates_parser
 
 
+def get_conflicts_parser():
+    # optional search text, start and end filters
+    conflicts_parser = argparse.ArgumentParser(add_help=False)
+    conflicts_parser.add_argument('text', nargs='?', type=utils._u)
+    conflicts_parser.add_argument(
+            'start', type=utils.get_time_from_str, nargs='?')
+    conflicts_parser.add_argument(
+            'end', type=utils.get_time_from_str, nargs='?')
+    return conflicts_parser
+
+
 def get_start_end_parser():
     se_parser = argparse.ArgumentParser(add_help=False)
     se_parser.add_argument('start', type=utils.get_time_from_str, nargs='?')
@@ -256,6 +267,7 @@ def get_argument_parser():
     remind_parser = get_remind_parser()
     cal_query_parser = get_cal_query_parser()
     updates_parser = get_updates_parser()
+    conflicts_parser = get_conflicts_parser()
 
     # parsed start and end times
     start_end_parser = get_start_end_parser()
@@ -303,6 +315,13 @@ def get_argument_parser():
             '(defaults to through end of current month)',
             description='Get updates since a datetime for a time period '
             '(default to through end of current month).')
+
+    sub.add_parser(
+            'conflicts',
+            parents=[details_parser, output_parser, conflicts_parser],
+            help='find event conflicts',
+            description='Find conflicts between events matching search term '
+            '(default from now through 30 days into futures)')
 
     calw = sub.add_parser(
             'calw', parents=[details_parser, output_parser, cal_query_parser],

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -160,6 +160,12 @@ def main():
                     start=parsed_args.start,
                     end=parsed_args.end)
 
+        elif parsed_args.command == 'conflicts':
+            gcal.ConflictsQuery(
+                    search_text=parsed_args.text,
+                    start=parsed_args.start,
+                    end=parsed_args.end)
+
         elif parsed_args.command == 'calw':
             gcal.CalQuery(
                     parsed_args.command, count=parsed_args.weeks,

--- a/gcalcli/conflicts.py
+++ b/gcalcli/conflicts.py
@@ -1,0 +1,22 @@
+
+class ShowConflicts:
+    active_events = []
+
+    def __init__(self, show):
+        if show:
+            self.show = show
+        else:
+            self.show = self._default_show
+
+    def show_conflicts(self, latest_event):
+        """Events must be passed in chronological order"""
+        start = latest_event['s']
+        for event in self.active_events:
+            if (event['e'] > start):
+                self.show(event)
+        self.active_events = list(
+            filter(lambda e: e['e'] > start, self.active_events))
+        self.active_events.append(latest_event)
+
+    def _default_show(self, e):
+        print(e)

--- a/tests/test_argparsers.py
+++ b/tests/test_argparsers.py
@@ -65,6 +65,16 @@ def test_updates_parser():
     assert parsed_updates.end
 
 
+def test_conflicts_parser():
+    updates_parser = argparsers.get_conflicts_parser()
+
+    argv = shlex.split('search 2019-08-01 2019-09-01')
+    parsed_conflicts = updates_parser.parse_args(argv)
+    assert parsed_conflicts.text
+    assert parsed_conflicts.start
+    assert parsed_conflicts.end
+
+
 def test_details_parser():
     details_parser = argparsers.get_details_parser()
 

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,43 @@
+from gcalcli.conflicts import ShowConflicts
+from datetime import datetime
+from dateutil.tz import tzlocal
+
+minimal_event = {
+                    'e': datetime(2019, 1, 8, 15, 15, tzinfo=tzlocal()),
+                    'id': 'minimial_event',
+                    's': datetime(2019, 1, 8, 14, 15, tzinfo=tzlocal())
+                 }
+minimal_event_overlapping = {
+                    'e': datetime(2019, 1, 8, 16, 15, tzinfo=tzlocal()),
+                    'id': 'minimial_event_overlapping',
+                    's': datetime(2019, 1, 8, 14, 30, tzinfo=tzlocal())
+                 }
+minimal_event_nonoverlapping = {
+                    'e': datetime(2019, 1, 8, 16, 15, tzinfo=tzlocal()),
+                    'id': 'minimal_event_nonoverlapping',
+                    's': datetime(2019, 1, 8, 15, 30, tzinfo=tzlocal())
+                 }
+
+
+def test_finds_no_conflicts_for_one_event():
+    """Basic test that only ensures the function can be run without error"""
+    conflicts = []
+    show_conflicts = ShowConflicts(conflicts.append)
+    show_conflicts.show_conflicts(minimal_event)
+    assert conflicts == []
+
+
+def test_finds_conflicts_for_second_overlapping_event():
+    conflicts = []
+    show_conflicts = ShowConflicts(conflicts.append)
+    show_conflicts.show_conflicts(minimal_event)
+    show_conflicts.show_conflicts(minimal_event_overlapping)
+    assert conflicts == [minimal_event]
+
+
+def test_does_not_find_conflict_for_second_non_overlapping_event():
+    conflicts = []
+    show_conflicts = ShowConflicts(conflicts.append)
+    show_conflicts.show_conflicts(minimal_event)
+    show_conflicts.show_conflicts(minimal_event_nonoverlapping)
+    assert conflicts == []

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -12,6 +12,7 @@ from gcalcli.argparsers import (get_start_end_parser,
                                 get_cal_query_parser,
                                 get_output_parser,
                                 get_updates_parser,
+                                get_conflicts_parser,
                                 get_search_parser)
 from gcalcli.gcal import GoogleCalendarInterface
 from gcalcli.cli import parse_cal_names
@@ -59,6 +60,17 @@ def test_updates(PatchedGCalI):
             ['2019-07-10', '2019-07-19', '2019-08-01'])
     assert PatchedGCalI().UpdatesQuery(
             last_updated_datetime=opts.since,
+            start=opts.start,
+            end=opts.end) == 0
+
+
+def test_conflicts(PatchedGCalI):
+    assert PatchedGCalI().ConflictsQuery() == 0
+
+    opts = get_conflicts_parser().parse_args(
+            ['search text', '2019-07-19', '2019-08-01'])
+    assert PatchedGCalI().ConflictsQuery(
+            'search text',
             start=opts.start,
             end=opts.end) == 0
 


### PR DESCRIPTION
This is useful for finding scheduling conflicts with your current events.

Future potential features:
  - add flag for a "buffer time" (e.g. 30 minutes) to account for travel time
  - add flag to import to check for conflicts before importing