### PR TITLE
Allow duration to be specified in multiple formats

### DIFF
--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -33,8 +33,8 @@ from gcalcli.gcal import GoogleCalendarInterface
 from gcalcli.printer import Printer, valid_color_name
 from gcalcli.utils import _u
 from gcalcli.validators import (
-        PARSABLE_DATE, REMINDER, STR_ALLOW_EMPTY, STR_NOT_EMPTY, STR_TO_INT,
-        get_input
+        PARSABLE_DATE, REMINDER, STR_ALLOW_EMPTY, STR_NOT_EMPTY,
+        PARSABLE_DURATION, get_input
 )
 
 CalName = namedtuple('CalName', ['name', 'color'])
@@ -71,8 +71,8 @@ def run_add_prompt(parsed_args, printer):
         if parsed_args.allday:
             prompt = 'Duration (days): '
         else:
-            prompt = 'Duration (minutes): '
-        parsed_args.duration = get_input(printer, prompt, STR_TO_INT)
+            prompt = 'Duration (human readable): '
+        parsed_args.duration = get_input(printer, prompt, PARSABLE_DURATION)
     if parsed_args.description is None:
         parsed_args.description = get_input(
             printer, 'Description: ', STR_ALLOW_EMPTY)

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -18,7 +18,7 @@ from gcalcli.utils import days_since_epoch, _u
 
 from gcalcli.validators import (
     get_input, get_override_color_id, STR_NOT_EMPTY, PARSABLE_DATE, STR_TO_INT,
-    VALID_COLORS, STR_ALLOW_EMPTY, REMINDER
+    VALID_COLORS, STR_ALLOW_EMPTY, REMINDER, PARSABLE_DURATION
 )
 
 from gcalcli.exceptions import GcalcliError
@@ -956,7 +956,8 @@ class GoogleCalendarInterface:
 
             elif val.lower() == 'g':
                 val = get_input(
-                        self.printer, 'Length (mins): ', STR_TO_INT
+                        self.printer, 'Length (mins or human readable): ',
+                        PARSABLE_DURATION
                 )
                 if val:
                     all_day = self.options.get('allday')

--- a/gcalcli/validators.py
+++ b/gcalcli/validators.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 import re
 
 from gcalcli.exceptions import ValidationError
-from gcalcli.utils import REMINDER_REGEX, get_time_from_str
+from gcalcli.utils import (REMINDER_REGEX, get_time_from_str,
+                           get_timedelta_from_str)
 from six.moves import input
 
 # TODO: in the future, pull these from the API
@@ -77,6 +78,22 @@ def parsable_date_validator(input_str):
         )
 
 
+def parsable_duration_validator(input_str):
+    """
+    A filter allowing any duration string which can be parsed
+    by parsedatetime.
+    Raises ValidationError otherwise.
+    """
+    try:
+        get_timedelta_from_str(input_str)
+        return input_str
+    except ValueError:
+        raise ValidationError(
+            'Expected format: a duration (e.g. 1m, 1s, 1h3m)'
+            '(Ctrl-C to exit)\n'
+        )
+
+
 def str_allow_empty_validator(input_str):
     """
     A simple filter that allows any string to pass.
@@ -123,5 +140,6 @@ STR_NOT_EMPTY = non_blank_str_validator
 STR_ALLOW_EMPTY = str_allow_empty_validator
 STR_TO_INT = str_to_int_validator
 PARSABLE_DATE = parsable_date_validator
+PARSABLE_DURATION = parsable_duration_validator
 VALID_COLORS = color_validator
 REMINDER = reminder_validator

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -3,6 +3,7 @@ import pytest
 from gcalcli.validators import validate_input, ValidationError
 from gcalcli.validators import (STR_NOT_EMPTY,
                                 PARSABLE_DATE,
+                                PARSABLE_DURATION,
                                 STR_TO_INT,
                                 STR_ALLOW_EMPTY,
                                 REMINDER,
@@ -23,15 +24,17 @@ import gcalcli.validators
 def test_any_string_not_blank_validator(monkeypatch):
     # Empty string raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "")
-    with pytest.raises(ValidationError):
-        validate_input(STR_NOT_EMPTY) == ValidationError(
-            "Input here cannot be empty")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(STR_NOT_EMPTY)
+    assert ve.value.message == ("Input here cannot be empty. "
+                                "(Ctrl-C to exit)\n")
 
     # None raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: None)
-    with pytest.raises(ValidationError):
-        validate_input(STR_NOT_EMPTY) == ValidationError(
-            "Input here cannot be empty")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(STR_NOT_EMPTY)
+    assert ve.value.message == ("Input here cannot be empty. "
+                                "(Ctrl-C to exit)\n")
 
     # Valid string passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "Valid Text")
@@ -41,8 +44,9 @@ def test_any_string_not_blank_validator(monkeypatch):
 def test_any_string_parsable_by_dateutil(monkeypatch):
     # non-date raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "NON-DATE STR")
-    with pytest.raises(ValidationError):
-        validate_input(PARSABLE_DATE) == ValidationError(
+    with pytest.raises(ValidationError) as ve:
+        validate_input(PARSABLE_DATE)
+    assert ve.value.message == (
             "Expected format: a date (e.g. 2019-01-01, tomorrow 10am, "
             "2nd Jan, Jan 4th, etc) or valid time if today. "
             "(Ctrl-C to exit)\n"
@@ -50,67 +54,93 @@ def test_any_string_parsable_by_dateutil(monkeypatch):
 
     # date string passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "2nd January")
-    validate_input(PARSABLE_DATE) == "2nd January"
+    assert validate_input(PARSABLE_DATE) == "2nd January"
+
+
+def test_any_string_parsable_by_parsedatetime(monkeypatch):
+    # non-date raises ValidationError
+    monkeypatch.setattr(gcalcli.validators, "input", lambda: "NON-DATE STR")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(PARSABLE_DURATION)
+    assert ve.value.message == (
+            'Expected format: a duration (e.g. 1m, 1s, 1h3m)'
+            '(Ctrl-C to exit)\n'
+        )
+
+    # duration string passes
+    monkeypatch.setattr(gcalcli.validators, "input", lambda: "1m")
+    assert validate_input(PARSABLE_DURATION) == "1m"
+
+    # duration string passes
+    monkeypatch.setattr(gcalcli.validators, "input", lambda: "1h2m")
+    assert validate_input(PARSABLE_DURATION) == "1h2m"
 
 
 def test_string_can_be_cast_to_int(monkeypatch):
     # non int-castable string raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "X")
-    with pytest.raises(ValidationError):
-        validate_input(STR_TO_INT) == ValidationError(
-            "Input here must be a number")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(STR_TO_INT)
+    assert ve.value.message == ("Input here must be a number. "
+                                "(Ctrl-C to exit)\n")
 
     # int string passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "10")
-    validate_input(STR_TO_INT) == "10"
+    assert validate_input(STR_TO_INT) == "10"
 
 
 def test_for_valid_colour_name(monkeypatch):
     # non valid colour raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "purple")
-    with pytest.raises(ValidationError):
-        validate_input(VALID_COLORS) == ValidationError(
-            "purple is not a valid color value to use here. Please "
-            "use one of basil, peacock, grape, lavender, blueberry,"
-            "tomato, safe, flamingo or banana."
-        )
+    with pytest.raises(ValidationError) as ve:
+        validate_input(VALID_COLORS)
+
+    assert ve.value.message == (
+        "Expected colors are: lavender, sage, grape, flamingo, banana, "
+        "tangerine, peacock, graphite, blueberry, basil, tomato. "
+        "(Ctrl-C to exit)\n"
+    )
+
     # valid colour passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "grape")
-    validate_input(VALID_COLORS) == "grape"
+    assert validate_input(VALID_COLORS) == "grape"
 
     # empty str passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "")
-    validate_input(VALID_COLORS) == ""
+    assert validate_input(VALID_COLORS) == ""
 
 
 def test_any_string_and_blank(monkeypatch):
     # string passes
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "TEST")
-    validate_input(STR_ALLOW_EMPTY) == "TEST"
+    assert validate_input(STR_ALLOW_EMPTY) == "TEST"
 
 
 def test_reminder(monkeypatch):
     # valid reminders pass
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "10m email")
-    validate_input(REMINDER) == "10m email"
+    assert validate_input(REMINDER) == "10m email"
 
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "10 popup")
-    validate_input(REMINDER) == "10m email"
+    assert validate_input(REMINDER) == "10 popup"
 
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "10m sms")
-    validate_input(REMINDER) == "10m email"
+    assert validate_input(REMINDER) == "10m sms"
 
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "12323")
-    validate_input(REMINDER) == "10m email"
+    assert validate_input(REMINDER) == "12323"
 
     # invalid reminder raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "meaningless")
-    with pytest.raises(ValidationError):
-        validate_input(REMINDER) == ValidationError(
-            "Format: <number><w|d|h|m> <popup|email|sms>\n")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(REMINDER)
+    assert ve.value.message == ('Expected format: <number><w|d|h|m> '
+                                '<popup|email|sms>. (Ctrl-C to exit)\n')
 
     # invalid reminder raises ValidationError
     monkeypatch.setattr(gcalcli.validators, "input", lambda: "")
-    with pytest.raises(ValidationError):
-        validate_input(REMINDER) == ValidationError(
-            "Format: <number><w|d|h|m> <popup|email|sms>\n")
+    with pytest.raises(ValidationError) as ve:
+        validate_input(REMINDER)
+
+    assert ve.value.message == ('Expected format: <number><w|d|h|m> '
+                                '<popup|email|sms>. (Ctrl-C to exit)\n')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import gcalcli.utils as utils
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.tz import UTC
 import six
 import pytest
@@ -9,6 +9,28 @@ def test_get_time_from_str():
     assert utils.get_time_from_str('7am tomorrow')
 
 
+def test_get_parsed_timedelta_from_str():
+    assert utils.get_timedelta_from_str('3.5h') == timedelta(
+                                        hours=3, minutes=30)
+    assert utils.get_timedelta_from_str('1') == timedelta(minutes=1)
+    assert utils.get_timedelta_from_str('1m') == timedelta(minutes=1)
+    assert utils.get_timedelta_from_str('1h') == timedelta(hours=1)
+    assert utils.get_timedelta_from_str('1h1m') == timedelta(
+                                        hours=1, minutes=1)
+    assert utils.get_timedelta_from_str('1:10') == timedelta(
+                                        hours=1, minutes=10)
+    assert utils.get_timedelta_from_str('2d:1h:3m') == timedelta(
+                                        days=2, hours=1, minutes=3)
+    assert utils.get_timedelta_from_str('2d 1h 3m 10s') == timedelta(
+                                        days=2, hours=1, minutes=3, seconds=10)
+    assert utils.get_timedelta_from_str(
+        '2 days 1 hour 2 minutes 40 seconds') == timedelta(
+                                        days=2, hours=1, minutes=2, seconds=40)
+    with pytest.raises(ValueError) as ve:
+        utils.get_timedelta_from_str('junk')
+    assert str(ve.value) == "Duration is invalid: junk"
+
+
 def test_get_times_from_duration():
     begin_1970 = '1970-01-01'
     begin_1970_midnight = begin_1970 + 'T00:00:00+00:00'
@@ -16,6 +38,14 @@ def test_get_times_from_duration():
     next_day = '1970-01-02'
     assert (begin_1970_midnight, two_hrs_later) == \
         utils.get_times_from_duration(begin_1970_midnight, duration=120)
+
+    assert (begin_1970_midnight, two_hrs_later) == \
+        utils.get_times_from_duration(
+            begin_1970_midnight, duration="2h")
+
+    assert (begin_1970_midnight, two_hrs_later) == \
+        utils.get_times_from_duration(
+            begin_1970_midnight, duration="120m")
 
     assert (begin_1970, next_day) == \
         utils.get_times_from_duration(


### PR DESCRIPTION
For example
 - 3.5h
 - 3m
 - 2 (defaults to minutes)
 - 2h4m2s

Fixes #514