### PR TITLE
[Proposal] add conference option `add --conference`  or `add --details conference`

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -374,6 +374,7 @@ def get_argument_parser():
     add.add_argument(
             '--noprompt', action='store_false', dest='prompt', default=True,
             help='Don\'t prompt for missing data when adding events')
+    add.add_argument('--conference', action='store_true', default=False, help='Create google meets')
 
     _import = sub.add_parser(
             'import', parents=[remind_parser],

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -200,7 +200,7 @@ def main():
 
             gcal.AddEvent(parsed_args.title, parsed_args.where, estart, eend,
                           parsed_args.description, parsed_args.who,
-                          parsed_args.reminders, parsed_args.event_color)
+                          parsed_args.reminders, parsed_args.event_color, parsed_args.conference)
 
         elif parsed_args.command == 'search':
             gcal.TextQuery(

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -7,6 +7,7 @@ import textwrap
 import json
 import random
 import sys
+import uuid
 from unicodedata import east_asian_width
 try:
     import cPickle as pickle
@@ -1369,9 +1370,13 @@ class GoogleCalendarInterface:
 
         event['attendees'] = list(map(lambda w: {'email': w}, who))
 
+        if self.details.get('conference'):
+            event['conferenceData'] = { 'createRequest': {'requestId': str(uuid.uuid4())[-10:],
+                                                         'conferenceSolutionKey' : {'type': 'hangoutsMeet' }}}
+
         event = self._add_reminders(event, reminders)
         events = self.get_cal_service().events()
-        request = events.insert(calendarId=self.cals[0]['id'], body=event)
+        request = events.insert(calendarId=self.cals[0]['id'], conferenceDataVersion=1, body=event)
         new_event = self._retry_with_backoff(request)
 
         if self.details.get('url'):

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1326,7 +1326,7 @@ class GoogleCalendarInterface:
 
         return new_event
 
-    def AddEvent(self, title, where, start, end, descr, who, reminders, color):
+    def AddEvent(self, title, where, start, end, descr, who, reminders, color, conference):
 
         if len(self.cals) != 1:
             # Calendar not specified. Prompt the user to select it
@@ -1370,7 +1370,7 @@ class GoogleCalendarInterface:
 
         event['attendees'] = list(map(lambda w: {'email': w}, who))
 
-        if self.details.get('conference'):
+        if  conference or self.details.get('conference'):
             event['conferenceData'] = { 'createRequest': {'requestId': str(uuid.uuid4())[-10:],
                                                          'conferenceSolutionKey' : {'type': 'hangoutsMeet' }}}
 

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -106,8 +106,9 @@ def test_add_event(PatchedGCalI):
     who = 'anyone'
     reminders = None
     color = "banana"
+    conference = False
     assert gcal.AddEvent(
-        title, where, start, end, descr, who, reminders, color)
+        title, where, start, end, descr, who, reminders, color, conference)
 
 
 def test_add_event_override_color(capsys, default_options,


### PR DESCRIPTION
I want to make a  new event with Google Meet url.
Therefore, I would suggest adding the `conference` option to the `add` command.

I tried to add a `--detail conference` and `--conference`.

Please check it and consider this change.