### PR TITLE
Update documented syntax for manual login options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,8 +142,8 @@ If desired, you can use your own Calendar API instead of the default API values.
 * Go back to the credentials page and grab your ID and Secret.
 * If desired, add the client-id and client-secret to your .gcalclirc:
 
-        --client-id=xxxxxxxxxxxxxxx.apps.googleusercontent.com
-        --client-secret=xxxxxxxxxxxxxxxxx
+        --client_id=xxxxxxxxxxxxxxx.apps.googleusercontent.com
+        --client_secret=xxxxxxxxxxxxxxxxx
 
 * Remove your existing OAuth information (typically ~/.gcalcli_oauth).
 * Run gcalcli with any desired argument, making sure the new client-id and


### PR DESCRIPTION
Changed hyphens to underscores in authentication option names. As mentioned in issue #523, the options need underscores (not hyphens) yet the documentation still instructed to use hyphens.