### PR TITLE
Add `agendaupdate` subcommand

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import argparse
 import gcalcli
 from gcalcli import utils
+from gcalcli.details import DETAILS
 from gcalcli.deprecations import parser_allow_deprecated, DeprecatedStoreTrue
 from gcalcli.printer import valid_color_name
 from oauth2client import tools
@@ -9,10 +10,6 @@ from shutil import get_terminal_size
 import copy as _copy
 import datetime
 import locale
-
-DETAILS = ['calendar', 'location', 'length', 'reminders', 'description',
-           'url', 'conference', 'attendees', 'email', 'attachments', 'end']
-
 
 PROGRAM_OPTIONS = {
         '--client-id': {'default': gcalcli.__API_CLIENT_ID__,

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -10,6 +10,7 @@ from shutil import get_terminal_size
 import copy as _copy
 import datetime
 import locale
+import sys
 
 PROGRAM_OPTIONS = {
         '--client-id': {'default': gcalcli.__API_CLIENT_ID__,
@@ -304,6 +305,13 @@ def get_argument_parser():
             parents=[details_parser, output_parser, start_end_parser],
             help='get an agenda for a time period',
             description='Get an agenda for a time period.')
+
+    agendaupdate = sub.add_parser(
+            'agendaupdate',
+            help='update calendar from agenda TSV file',
+            description='Update calendar from agenda TSV file.')
+    agendaupdate.add_argument(
+        'file', type=argparse.FileType('r'), nargs='?', default=sys.stdin)
 
     sub.add_parser(
             'updates',

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -151,6 +151,9 @@ def main():
         elif parsed_args.command == 'agenda':
             gcal.AgendaQuery(start=parsed_args.start, end=parsed_args.end)
 
+        elif parsed_args.command == 'agendaupdate':
+            gcal.AgendaUpdate(parsed_args.file)
+
         elif parsed_args.command == 'updates':
             gcal.UpdatesQuery(
                     last_updated_datetime=parsed_args.since,

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -126,9 +126,16 @@ class Email(SingleColumnHandler):
         return event['creator'].get('email', '')
 
 
+class ID(SimpleSingleColumnHandler):
+    """Handler for event ID."""
+
+    header = ['id']
+
+
 HANDLERS_DEFAULT = {'time', 'title'}
 
-HANDLERS = OrderedDict([('time', Time),
+HANDLERS = OrderedDict([('id', ID),
+                        ('time', Time),
                         ('url', Url),
                         ('conference', Conference),
                         ('title', Title),

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -28,7 +28,7 @@ class Handler:
         raise NotImplementedError
 
     @classmethod
-    def patch(cls, event, value):
+    def patch(cls, event, fieldname, value):
         """Patch event from value."""
         raise NotImplementedError
 
@@ -40,6 +40,10 @@ class SingleFieldHandler(Handler):
     def get(cls, event):
         return [cls._get(event).strip()]
 
+    @classmethod
+    def patch(cls, event, fieldname, value):
+        cls._patch(cls, event, value)
+
 
 class SimpleSingleFieldHandler(SingleFieldHandler):
     """Handler for single-string details that require no special processing."""
@@ -49,7 +53,7 @@ class SimpleSingleFieldHandler(SingleFieldHandler):
         return event.get(cls.fieldnames[0], '')
 
     @classmethod
-    def patch(cls, event, value):
+    def _patch(cls, event, value):
         event[cls.fieldnames[0]] = value
 
 
@@ -104,7 +108,7 @@ class Title(SingleFieldHandler):
         return _valid_title(event)
 
     @classmethod
-    def patch(cls, event, value):
+    def _patch(cls, event, value):
         event['summary'] = value
 
 

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -17,9 +17,9 @@ def _valid_title(event):
 class Handler:
     """Handler for a specific detail of an event."""
 
-    # list of strings for headers provided by this object
-    # XXX: py36+: change to `header: List[str]`
-    header = None  # type: Optional[List[str]]
+    # list of strings for fieldnames provided by this object
+    # XXX: py36+: change to `fieldnames: List[str]`
+    fieldnames = None  # type: Optional[List[str]]
 
     @classmethod
     def get(cls, event):
@@ -27,7 +27,7 @@ class Handler:
         raise NotImplementedError
 
 
-class SingleColumnHandler(Handler):
+class SingleFieldHandler(Handler):
     """Handler for a detail that only produces one column."""
 
     @classmethod
@@ -35,18 +35,18 @@ class SingleColumnHandler(Handler):
         return [cls._get(event).strip()]
 
 
-class SimpleSingleColumnHandler(SingleColumnHandler):
+class SimpleSingleFieldHandler(SingleFieldHandler):
     """Handler for single-string details that require no special processing."""
 
     @classmethod
     def _get(cls, event):
-        return event.get(cls.header[0], '')
+        return event.get(cls.fieldnames[0], '')
 
 
 class Time(Handler):
     """Handler for dates and times."""
 
-    header = ['start_date', 'start_time', 'end_date', 'end_time']
+    fieldnames = ['start_date', 'start_time', 'end_date', 'end_time']
 
     @classmethod
     def get(cls, event):
@@ -57,7 +57,7 @@ class Time(Handler):
 class Url(Handler):
     """Handler for HTML and legacy Hangout links."""
 
-    header = ['html_link', 'hangout_link']
+    fieldnames = ['html_link', 'hangout_link']
 
     @classmethod
     def get(cls, event):
@@ -68,7 +68,7 @@ class Url(Handler):
 class Conference(Handler):
     """Handler for videoconference and teleconference details."""
 
-    header = ['conference_entry_point_type', 'conference_uri']
+    fieldnames = ['conference_entry_point_type', 'conference_uri']
 
     @classmethod
     def get(cls, event):
@@ -84,52 +84,52 @@ class Conference(Handler):
         return [entry_point['entryPointType'], entry_point['uri']]
 
 
-class Title(SingleColumnHandler):
+class Title(SingleFieldHandler):
     """Handler for title."""
 
-    header = ['title']
+    fieldnames = ['title']
 
     @classmethod
     def _get(cls, event):
         return _valid_title(event)
 
 
-class Location(SimpleSingleColumnHandler):
+class Location(SimpleSingleFieldHandler):
     """Handler for location."""
 
-    header = ['location']
+    fieldnames = ['location']
 
 
-class Description(SimpleSingleColumnHandler):
+class Description(SimpleSingleFieldHandler):
     """Handler for description."""
 
-    header = ['description']
+    fieldnames = ['description']
 
 
-class Calendar(SingleColumnHandler):
+class Calendar(SingleFieldHandler):
     """Handler for calendar."""
 
-    header = ['calendar']
+    fieldnames = ['calendar']
 
     @classmethod
     def _get(cls, event):
         return event['gcalcli_cal']['summary']
 
 
-class Email(SingleColumnHandler):
+class Email(SingleFieldHandler):
     """Handler for emails."""
 
-    header = ['email']
+    fieldnames = ['email']
 
     @classmethod
     def _get(cls, event):
         return event['creator'].get('email', '')
 
 
-class ID(SimpleSingleColumnHandler):
+class ID(SimpleSingleFieldHandler):
     """Handler for event ID."""
 
-    header = ['id']
+    fieldnames = ['id']
 
 
 HANDLERS_DEFAULT = {'time', 'title'}

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -7,7 +7,7 @@ from typing import List
 
 from dateutil.parser import isoparse, parse
 
-from gcalcli.exceptions import GcalcliError
+from gcalcli.exceptions import ReadonlyError, ReadonlyCheckError
 from gcalcli.utils import is_all_day
 
 FMT_DATE = '%Y-%m-%d'
@@ -16,7 +16,8 @@ TODAY = datetime.now().date()
 
 URL_PROPS = OrderedDict([('html_link', 'htmlLink'),
                          ('hangout_link', 'hangoutLink')])
-ENTRY_POINT_PROPS = OrderedDict([('conference_entry_point_type', 'entryPointType'),
+ENTRY_POINT_PROPS = OrderedDict([('conference_entry_point_type',
+                                  'entryPointType'),
                                  ('conference_uri', 'uri')])
 
 
@@ -136,10 +137,10 @@ class Url(Handler):
     @classmethod
     def patch(cls, cal, event, fieldname, value):
         if fieldname == 'html_link':
-            raise GcalcliError('Field {} is read-only. '
-                               'It is not possible to verify that the value '
-                               'has not changed. '
-                               'Remove it from the input.'.format(fieldname))
+            raise ReadonlyError(fieldname,
+                                'It is not possible to verify that the value '
+                                'has not changed. '
+                                'Remove it from the input.')
 
         prop = URL_PROPS[fieldname]
 
@@ -150,9 +151,7 @@ class Url(Handler):
         curr_value = event.get(prop, '')
 
         if curr_value != value:
-            raise GcalcliError('Field {} is read-only. '
-                               'Current value "{}" does not match update value'
-                               ' "{}"'.format(fieldname, curr_value, value))
+            raise ReadonlyCheckError(fieldname, curr_value, value)
 
 
 class Conference(Handler):

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -144,3 +144,8 @@ HANDLERS = OrderedDict([('time', Time),
                         ('description', Description),
                         ('calendar', Calendar),
                         ('email', Email)])
+
+_DETAILS_WITHOUT_HANDLERS = ['length', 'reminders', 'attendees',
+                             'attachments', 'end']
+
+DETAILS = list(HANDLERS.keys()) + _DETAILS_WITHOUT_HANDLERS

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -13,6 +13,9 @@ FMT_DATE = '%Y-%m-%d'
 FMT_TIME = '%H:%M'
 TODAY = datetime.now().date()
 
+URL_PROPS = OrderedDict([('html_link', 'htmlLink'),
+                         ('hangout_link', 'hangoutLink')])
+
 
 def _valid_title(event):
     if 'summary' in event and event['summary'].strip():
@@ -121,12 +124,11 @@ class Time(Handler):
 class Url(Handler):
     """Handler for HTML and legacy Hangout links."""
 
-    fieldnames = ['html_link', 'hangout_link']
+    fieldnames = list(URL_PROPS.keys())
 
     @classmethod
     def get(cls, event):
-        return [event.get('htmlLink', ''),
-                event.get('hangoutLink', '')]
+        return [event.get(prop, '') for prop in URL_PROPS.values()]
 
 
 class Conference(Handler):

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -7,6 +7,8 @@ from typing import List
 
 from dateutil.parser import isoparse, parse
 
+from gcalcli.utils import is_all_day
+
 FMT_DATE = '%Y-%m-%d'
 FMT_TIME = '%H:%M'
 TODAY = datetime.now().date()
@@ -67,9 +69,24 @@ class Time(Handler):
     fieldnames = ['start_date', 'start_time', 'end_date', 'end_time']
 
     @classmethod
+    def _datetime_to_fields(cls, instant, all_day):
+        instant_date = instant.strftime(FMT_DATE)
+
+        if all_day:
+            instant_time = ''
+        else:
+            instant_time = instant.strftime(FMT_TIME)
+
+        return [instant_date, instant_time]
+
+    @classmethod
     def get(cls, event):
-        return [event['s'].strftime(FMT_DATE), event['s'].strftime(FMT_TIME),
-                event['e'].strftime(FMT_DATE), event['e'].strftime(FMT_TIME)]
+        all_day = is_all_day(event)
+
+        start_fields = cls._datetime_to_fields(event['s'], all_day)
+        end_fields = cls._datetime_to_fields(event['e'], all_day)
+
+        return start_fields + end_fields
 
     @classmethod
     def patch(cls, cal, event, fieldname, value):

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -16,6 +16,8 @@ TODAY = datetime.now().date()
 
 URL_PROPS = OrderedDict([('html_link', 'htmlLink'),
                          ('hangout_link', 'hangoutLink')])
+ENTRY_POINT_PROPS = OrderedDict([('conference_entry_point_type', 'entryPointType'),
+                                 ('conference_uri', 'uri')])
 
 
 def _valid_title(event):
@@ -156,7 +158,7 @@ class Url(Handler):
 class Conference(Handler):
     """Handler for videoconference and teleconference details."""
 
-    fieldnames = ['conference_entry_point_type', 'conference_uri']
+    fieldnames = list(ENTRY_POINT_PROPS.keys())
 
     @classmethod
     def get(cls, event):
@@ -169,7 +171,23 @@ class Conference(Handler):
         # https://github.com/insanum/gcalcli/issues/533
         entry_point = data['entryPoints'][0]
 
-        return [entry_point['entryPointType'], entry_point['uri']]
+        return [entry_point.get(prop, '')
+                for prop in ENTRY_POINT_PROPS.values()]
+
+    @classmethod
+    def patch(cls, cal, event, fieldname, value):
+        if not value:
+            return
+
+        prop = ENTRY_POINT_PROPS[fieldname]
+
+        data = event.setdefault('conferenceData', {})
+        entry_points = data.setdefault('entryPoints', [])
+        if not entry_points:
+            entry_points.append({})
+
+        entry_point = entry_points[0]
+        entry_point[prop] = value
 
 
 class Title(SingleFieldHandler):

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -1,0 +1,146 @@
+"""Handlers for specific details of events."""
+
+from collections import OrderedDict
+from typing import List, Optional
+
+FMT_DATE = '%Y-%m-%d'
+FMT_TIME = '%H:%M'
+
+
+def _valid_title(event):
+    if 'summary' in event and event['summary'].strip():
+        return event['summary']
+    else:
+        return '(No title)'
+
+
+class Handler:
+    """Handler for a specific detail of an event."""
+
+    # list of strings for headers provided by this object
+    # XXX: py36+: change to `header: List[str]`
+    header = None  # type: Optional[List[str]]
+
+    @classmethod
+    def get(cls, event):
+        """Return simple string representation for columnar output."""
+        raise NotImplementedError
+
+
+class SingleColumnHandler(Handler):
+    """Handler for a detail that only produces one column."""
+
+    @classmethod
+    def get(cls, event):
+        return [cls._get(event).strip()]
+
+
+class SimpleSingleColumnHandler(SingleColumnHandler):
+    """Handler for single-string details that require no special processing."""
+
+    # XXX: py36+: change to `_key: str`
+    _key = None  # type: Optional[str]
+
+    @property
+    def header(self):
+        """Getter property that returns a list of `self._key`."""
+        return [self._key]
+
+    @classmethod
+    def _get(cls, event):
+        return event.get(cls._key, '')
+
+
+class Time(Handler):
+    """Handler for dates and times."""
+
+    header = ['start_date', 'start_time', 'end_date', 'end_time']
+
+    @classmethod
+    def get(cls, event):
+        return [event['s'].strftime(FMT_DATE), event['s'].strftime(FMT_TIME),
+                event['e'].strftime(FMT_DATE), event['e'].strftime(FMT_TIME)]
+
+
+class Url(Handler):
+    """Handler for HTML and legacy Hangout links."""
+
+    header = ['html_link', 'hangout_link']
+
+    @classmethod
+    def get(cls, event):
+        return [event.get('htmlLink', ''),
+                event.get('hangoutLink', '')]
+
+
+class Conference(Handler):
+    """Handler for videoconference and teleconference details."""
+
+    header = ['conference_entry_point_type', 'conference_uri']
+
+    @classmethod
+    def get(cls, event):
+        if 'conferenceData' not in event:
+            return ['', '']
+
+        data = event['conferenceData']
+
+        # only display first entry point for TSV
+        # https://github.com/insanum/gcalcli/issues/533
+        entry_point = data['entryPoints'][0]
+
+        return [entry_point['entryPointType'], entry_point['uri']]
+
+
+class Title(SingleColumnHandler):
+    """Handler for title."""
+
+    header = ['title']
+
+    @classmethod
+    def _get(cls, event):
+        return _valid_title(event)
+
+
+class Location(SimpleSingleColumnHandler):
+    """Handler for location."""
+
+    _key = 'location'
+
+
+class Description(SimpleSingleColumnHandler):
+    """Handler for description."""
+
+    _key = 'description'
+
+
+class Calendar(SingleColumnHandler):
+    """Handler for calendar."""
+
+    header = ['calendar']
+
+    @classmethod
+    def _get(cls, event):
+        return event['gcalcli_cal']['summary']
+
+
+class Email(SingleColumnHandler):
+    """Handler for emails."""
+
+    header = ['email']
+
+    @classmethod
+    def _get(cls, event):
+        return event['creator'].get('email', '')
+
+
+HANDLERS_DEFAULT = {'time', 'title'}
+
+HANDLERS = OrderedDict([('time', Time),
+                        ('url', Url),
+                        ('conference', Conference),
+                        ('title', Title),
+                        ('location', Location),
+                        ('description', Description),
+                        ('calendar', Calendar),
+                        ('email', Email)])

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -224,6 +224,13 @@ class Calendar(SingleFieldHandler):
     def _get(cls, event):
         return event['gcalcli_cal']['summary']
 
+    @classmethod
+    def patch(cls, cal, event, fieldname, value):
+        curr_value = cal['summary']
+
+        if curr_value != value:
+            raise ReadonlyCheckError(fieldname, curr_value, value)
+
 
 class Email(SingleFieldHandler):
     """Handler for emails."""
@@ -250,7 +257,7 @@ HANDLERS = OrderedDict([('id', ID),
                         ('description', Description),
                         ('calendar', Calendar),
                         ('email', Email)])
-HANDLERS_READONLY = {Url}
+HANDLERS_READONLY = {Url, Calendar}
 
 FIELD_HANDLERS = dict(chain.from_iterable(
     (((fieldname, handler)

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -38,17 +38,9 @@ class SingleColumnHandler(Handler):
 class SimpleSingleColumnHandler(SingleColumnHandler):
     """Handler for single-string details that require no special processing."""
 
-    # XXX: py36+: change to `_key: str`
-    _key = None  # type: Optional[str]
-
-    @property
-    def header(self):
-        """Getter property that returns a list of `self._key`."""
-        return [self._key]
-
     @classmethod
     def _get(cls, event):
-        return event.get(cls._key, '')
+        return event.get(cls.header[0], '')
 
 
 class Time(Handler):
@@ -105,13 +97,13 @@ class Title(SingleColumnHandler):
 class Location(SimpleSingleColumnHandler):
     """Handler for location."""
 
-    _key = 'location'
+    header = ['location']
 
 
 class Description(SimpleSingleColumnHandler):
     """Handler for description."""
 
-    _key = 'description'
+    header = ['description']
 
 
 class Calendar(SingleColumnHandler):

--- a/gcalcli/exceptions.py
+++ b/gcalcli/exceptions.py
@@ -8,6 +8,19 @@ class ValidationError(Exception):
         self.message = message
 
 
+class ReadonlyError(Exception):
+    def __init__(self, fieldname, message):
+        message = 'Field {} is read-only. {}'.format(fieldname, message)
+        super(ReadonlyError, self).__init__(message)
+
+
+class ReadonlyCheckError(ReadonlyError):
+    _fmt = 'Current value "{}" does not match update value "{}"'
+
+    def __init__(self, fieldname, curr_value, mod_value):
+        message = self._fmt.format(curr_value, mod_value)
+        super(ReadonlyCheckError, self).__init__(fieldname, message)
+
 def raise_one_cal_error(cals):
     raise GcalcliError(
         'You must only specify a single calendar\n'

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -41,6 +41,7 @@ from collections import namedtuple
 
 EventTitle = namedtuple('EventTitle', ['title', 'color'])
 
+CONFERENCE_DATA_VERSION = 1
 
 class GoogleCalendarInterface:
 
@@ -1248,6 +1249,7 @@ class GoogleCalendarInterface:
                     .patch(
                         calendarId=cal_id,
                         eventId=mod_event['id'],
+                        conferenceDataVersion=CONFERENCE_DATA_VERSION,
                         body=mod_event
                     )
             )

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -592,7 +592,7 @@ class GoogleCalendarInterface:
                     for key, handler in HANDLERS.items()
                     if key in keys]
 
-        header_row = chain.from_iterable(handler.header
+        header_row = chain.from_iterable(handler.fieldnames
                                          for handler in handlers)
         print(*header_row, sep='\t')
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1214,13 +1214,14 @@ class GoogleCalendarInterface:
         if len(self.cals) != 1:
             raise GcalcliError('Must specify a single calendar.')
 
-        cal_id = self.cals[0]['id']
+        cal = self.cals[0]
+        cal_id = cal['id']
 
         for row in reader:
             event = {}
 
             for fieldname, value in row.items():
-                FIELD_HANDLERS[fieldname].patch(event, value)
+                FIELD_HANDLERS[fieldname].patch(cal, event, fieldname, value)
 
             self._retry_with_backoff(
                 self.get_cal_service()

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -2,6 +2,7 @@ import os
 import re
 import shlex
 import httplib2
+from itertools import chain
 import time
 import textwrap
 import json
@@ -589,6 +590,10 @@ class GoogleCalendarInterface:
                     for key, handler in HANDLERS.items()
                     if key in keys]
 
+        header_row = chain.from_iterable(handler.header
+                                         for handler in handlers)
+        print(*header_row, sep='\t')
+
         for event in event_list:
             if self.options['ignore_started'] and (event['s'] < self.now):
                 continue
@@ -599,8 +604,8 @@ class GoogleCalendarInterface:
             for handler in handlers:
                 row.extend(handler.get(event))
 
-            output = '%s\n' % ('\t'.join(row)).replace('\n', '''\\n''')
-            sys.stdout.write(output)
+            output = ('\t'.join(row)).replace('\n', '''\\n''')
+            print(output)
 
     def _PrintEvent(self, event, prefix):
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -19,7 +19,7 @@ from gcalcli import __program__, __version__
 from gcalcli import utils
 from gcalcli.details import (_valid_title, FIELD_HANDLERS, HANDLERS,
                              HANDLERS_DEFAULT)
-from gcalcli.utils import days_since_epoch
+from gcalcli.utils import days_since_epoch, is_all_day
 from gcalcli.validators import (
     get_input, get_override_color_id, STR_NOT_EMPTY, PARSABLE_DATE, STR_TO_INT,
     VALID_COLORS, STR_ALLOW_EMPTY, REMINDER, PARSABLE_DURATION
@@ -251,10 +251,6 @@ class GoogleCalendarInterface:
         else:
             return 'default'
 
-    def _isallday(self, event):
-        return event['s'].hour == 0 and event['s'].minute == 0 and \
-            event['e'].hour == 0 and event['e'].minute == 0
-
     def _cal_monday(self, day_num):
         """Shift the day number if we're doing cal monday, or cal_weekend is
         false, since that also means we're starting on day 1
@@ -301,7 +297,7 @@ class GoogleCalendarInterface:
 
         for event in event_list:
             event_daynum = self._cal_monday(int(event['s'].strftime('%w')))
-            event_allday = self._isallday(event)
+            event_allday = is_all_day(event)
 
             event_end_date = event['e']
             if event_allday:
@@ -646,7 +642,7 @@ class GoogleCalendarInterface:
         self.printer.msg(prefix, self.options['color_date'])
 
         happening_now = event['s'] <= self.now <= event['e']
-        all_day = self._isallday(event)
+        all_day = is_all_day(event)
         if self.options['override_color'] and event.get('colorId'):
             if happening_now and not all_day:
                 event_color = self.options['color_now_marker']

--- a/gcalcli/utils.py
+++ b/gcalcli/utils.py
@@ -143,3 +143,12 @@ def agenda_time_fmt(dt, military):
     hour_min_fmt = '%H:%M' if military else '%I:%M'
     ampm = '' if military else dt.strftime('%p').lower()
     return dt.strftime(hour_min_fmt).lstrip('0') + ampm
+
+
+def is_all_day(event):
+    # XXX: currently gcalcli represents all-day events as those that both begin
+    # and end at midnight. This is ambiguous with Google Calendar events that
+    # are not all-day but happen to begin and end at midnight.
+
+    return (event['s'].hour == 0 and event['s'].minute == 0
+            and event['e'].hour == 0 and event['e'].minute == 0)

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,6 @@ commands=py.test -vv --cov=./gcalcli --pyargs tests {posargs}
 
 [flake8]
 exclude=.git,__pycache__,venv,.tox,.venv
+per-file-ignores=details.py:D102
+
+# don't want to create a docstring for every implementation of a virtual base method


### PR DESCRIPTION
Add the `agendaupdate` subcommand, the minimum viable product for #550.

Refactor `gcalcli.gcal.GoogleCalendarInterface._tsv()`, replacing the long list of if statements with a modular design using a series of `gcalcli.details.Handler` classes.

My plan is to keep making additions to the michaelmhoffman/issue-550 branch, pushing from my local machine when I have changes that implement each of the checklist items in #550. I test locally with Python 3.5-Python 3.8. Please feel free to review and apply now or when I'm done with the whole set.