### PR TITLE
Remove python 2-isms

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ nix-env -i gcalcli
 ### Install from PyPI
 
 ```sh
-pip install gcalcli
+pip3 install gcalcli
 ```
 
 ### Install from source
@@ -57,13 +57,13 @@ pip install gcalcli
 ```sh
 git clone https://github.com/insanum/gcalcli.git
 cd gcalcli
-python setup.py install
+python3 setup.py install
 ```
 
 ### Install optional package
 
 ```sh
-pip install vobject
+pip3 install vobject
 ```
 
 Features


### PR DESCRIPTION
As of bfcbe1228fe2d369cae2b09357499c7f6f5fce0e the support for Python 2
has been removed.
This commit removes `python` and `pip` calls, and instead replaces them
with `python3` and `pip3`, as these are the python 3 versions of those
calls