### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 sudo: false
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
         - "3.5"
         - "3.6"
         - "3.7"
+before_install:
+  - sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels
 install: pip install tox-travis
 script: tox


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/gcalcli/builds/187495199
Please have a look.

Regards,
ujjwal