### PR TITLE
add homebrew installation instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,12 @@ Check your OS distribution for packages.
 apt-get install gcalcli
 ```
 
+### Install using [Homebrew](https://brew.sh/)
+
+```sh
+brew install gcalcli
+```
+
 ### Install using [Nix](https://nixos.org/nix/)
 
 ```sh


### PR DESCRIPTION
Now that gcalcli is part of homebrew-core(see https://github.com/Homebrew/homebrew-core/pull/62935), adding installation instructions - see issue #394 