### PR TITLE
Remove whitespace before client-id in example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -141,10 +141,10 @@ If desired, you can use your own Calendar API instead of the default API values.
   up the OAuth website. Anything optional can safely be left blank.
 * Go back to the credentials page and grab your ID and Secret.
 * If desired, add the client-id and client-secret to your .gcalclirc:
-
-        --client-id=xxxxxxxxxxxxxxx.apps.googleusercontent.com
-        --client-secret=xxxxxxxxxxxxxxxxx
-
+```
+--client-id=xxxxxxxxxxxxxxx.apps.googleusercontent.com
+--client-secret=xxxxxxxxxxxxxxxxx
+```
 * Remove your existing OAuth information (typically ~/.gcalcli_oauth).
 * Run gcalcli with any desired argument, making sure the new client-id and
   client-secret are passed on the command line or placed in your .gcalclirc. The


### PR DESCRIPTION
When copying the example of adding a client-id to my `.gcalclirc` I got an error due to the spaces before the options. This removes the spaces.