### PR TITLE
Imported events update

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1602,6 +1602,7 @@ class GoogleCalendarInterface:
                 self.printer.err_msg('Error: ' + str(e) + '!\n')
                 sys.exit(1)
 
+        count = 0
         while True:
             try:
                 v = next(vobject.readComponents(f))
@@ -1617,40 +1618,30 @@ class GoogleCalendarInterface:
                 if dump:
                     continue
 
-                if not verbose:
-                    new_event = self._retry_with_backoff(
-                                    self.get_cal_service()
-                                        .events()
-                                        .insert(
-                                            calendarId=self.cals[0]['id'],
-                                            body=event
-                                        )
-                                )
-                    hlink = new_event.get('htmlLink')
-                    self.printer.msg(
-                            'New event added: %s\n' % hlink, 'green'
-                    )
-                    continue
+                if verbose:
+                    self.printer.msg('\n[S]kip [i]mport [q]uit: ', 'magenta')
+                    val = input()
+                    if not val or val.lower() == 's':
+                        continue
+                    elif val.lower() == 'i':
+                        pass
+                    elif val.lower() == 'q':
+                        sys.exit(0)
+                    else:
+                        self.printer.err_msg('Error: invalid input\n')
+                        sys.exit(1)
 
-                self.printer.msg('\n[S]kip [i]mport [q]uit: ', 'magenta')
-                val = input()
-                if not val or val.lower() == 's':
-                    continue
-                if val.lower() == 'i':
-                    new_event = self._retry_with_backoff(
-                                    self.get_cal_service()
-                                        .events()
-                                        .insert(
-                                            calendarId=self.cals[0]['id'],
-                                            body=event
-                                        )
-                                )
-                    hlink = new_event.get('htmlLink')
-                    self.printer.msg('New event added: %s\n' % hlink, 'green')
-                elif val.lower() == 'q':
-                    sys.exit(0)
-                else:
-                    self.printer.err_msg('Error: invalid input\n')
-                    sys.exit(1)
-        # TODO: return the number of events added
-        return True
+                new_event = self._retry_with_backoff(
+                                self.get_cal_service()
+                                    .events()
+                                    .insert(
+                                        calendarId=self.cals[0]['id'],
+                                        body=event
+                                    )
+                            )
+                hlink = new_event.get('htmlLink')
+                self.printer.msg(
+                        'New event added: %s\n' % hlink, 'green'
+                )
+                count += 1
+        return count

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1577,6 +1577,12 @@ class GoogleCalendarInterface:
                     event['attendees'].append({'displayName': attendee.name,
                                                'email': email})
 
+            if hasattr(ve, 'uid'):
+                uid = ve.uid.value.strip()
+                if verbose:
+                    print('UID..........%s' % uid)
+                event['iCalUID'] = uid
+
             return event
 
         try:
@@ -1631,13 +1637,15 @@ class GoogleCalendarInterface:
                         self.printer.err_msg('Error: invalid input\n')
                         sys.exit(1)
 
+                if 'iCalUID' in event:
+                    method = self.get_cal_service().events().import_
+                else:
+                    method = self.get_cal_service().events().insert
                 new_event = self._retry_with_backoff(
-                                self.get_cal_service()
-                                    .events()
-                                    .insert(
-                                        calendarId=self.cals[0]['id'],
-                                        body=event
-                                    )
+                                method(
+                                    calendarId=self.cals[0]['id'],
+                                    body=event
+                                )
                             )
                 hlink = new_event.get('htmlLink')
                 self.printer.msg(


### PR DESCRIPTION
This answers the same issues as pull request https://github.com/insanum/gcalcli/pull/584#issuecomment-839376331 (issues #492, #583), but actually updates the event (similarly to the google calendar "import" feature) instead of creating duplicates events or returning an error.

When using the command `import` on a `.ics` file with a specified UID, use the [import](https://developers.google.com/calendar/v3/reference/events/import) method instead of the [insert](https://developers.google.com/calendar/v3/reference/events/insert) method.
I've tested it and it works as intended (the event is replaced if already existing in the specified calendar).

Thanks to @tcheinen for having a first shot at this issue.