### PR TITLE
build(mypy): add `mypy.ini` with `ignore_missing_imports = True`

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -44,6 +44,7 @@ EventTitle = namedtuple('EventTitle', ['title', 'color'])
 
 CONFERENCE_DATA_VERSION = 1
 
+
 class GoogleCalendarInterface:
 
     cache = {}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
Fixes #612.

Make MyPy ignore missing imports.

- build(mypy): add `mypy.ini` with `ignore_missing_imports = True`
- style: add extra line to satisfy flake8 `E02`
