### PR TITLE
Avoid errors when using aliases in calendar invites

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1111,7 +1111,7 @@ class GoogleCalendarInterface:
     def _DeclinedEvent(self, event):
         if 'attendees' in event:
             attendees = [a for a in event['attendees']
-                         if a['email'] == event['gcalcli_cal']['id']]
+                         if 'self' in a]
             if attendees and attendees[0]['responseStatus'] == 'declined':
                 return True
         return False


### PR DESCRIPTION
If the calendar ID (i.e. the primary email) doesn't exactly match the invitee's email, `gcalcli agenda --nodeclined` will throw an error.

This change changes makes use of the 'self' property of the attendee to determine identity instead of comparing strings, thus enabling support for alias-based invitations. 

Now it's possible for firstname.lastname@domain.com to be invited as firstname@domain.com and still use `gcalcli agenda --nodeclined`.

https://github.com/insanum/gcalcli/issues/620