### PR TITLE
docs: `README.md`: add Void Linux

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,11 @@ Check your OS distribution for packages.
 apt-get install gcalcli
 ```
 
+### Void Linux 
+```sh
+xbps-install gcalcli
+```
+
 ### Install using [Nix](https://nixos.org/nix/)
 
 ```sh


### PR DESCRIPTION
Void Linux now has gcalcli in their [repositories](https://voidlinux.org/packages/?arch=x86_64&q=gcalcli). Maybe include this information in the README?