### PR TITLE
docs: fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -122,7 +122,7 @@ v2.4
   * Add support for fuzzy dates (today, tomorrow, next week) using parsedatetime
   * Empty descriptions no longer printed
   * Fixed print locations and reminders for agenda
-  * Allow outputing event URL as short URL using goo.gl
+  * Allow outputting event URL as short URL using goo.gl
   * Really minor change to display end dates in the --tsv view mode.
 
 v2.3

--- a/docs/README.md
+++ b/docs/README.md
@@ -267,7 +267,7 @@ exec herbstluftwm # :-)
 ```
 
 By default gcalcli executes the notify-send command for notifications. Most
-common Linux desktop enviroments already contain a DBUS notification daemon
+common Linux desktop environments already contain a DBUS notification daemon
 that supports libnotify so it should automagically just work. If you're like
 me and use nothing that is common I highly recommend the
 [dunst](https://github.com/knopwob/dunst) dmenu'ish notification daemon.
@@ -297,7 +297,7 @@ ${execpi 300 gcalcli --conky calw 3}
 You may need to increase the `text_buffer_size` in your conkyrc file.  Users
 have reported that the default of 256 bytes is too small for busy calendars.
 
-Additionaly you need to set `--lineart=unicode` to output unicode-characters
+Additionally you need to set `--lineart=unicode` to output unicode-characters
 for box drawing. To avoid misaligned borders use a monospace font like 'DejaVu
 Sans Mono'. On Python2 it might be necessary to set the environment variable
 `PYTHONIOENCODING=utf8` if you are using characters beyond ascii. For

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -285,7 +285,7 @@ def get_argument_parser():
     sub.add_parser(
             'search', parents=[details_parser, output_parser, search_parser],
             help='search for events within an optional time period',
-            description='Provides case insenstive search for calendar events.')
+            description='Provides case insensitive search for calendar events.')
     sub.add_parser(
             'edit', parents=[details_parser, output_parser, search_parser],
             help='edit calendar events',

--- a/tests/data/cal_service_discovery.json
+++ b/tests/data/cal_service_discovery.json
@@ -440,7 +440,7 @@
      "description": "A global palette of calendar colors, mapping from the color ID to its definition. A calendarListEntry resource refers to one of these color IDs in its color field. Read-only.",
      "additionalProperties": {
       "$ref": "ColorDefinition",
-      "description": "A calendar color defintion."
+      "description": "A calendar color definition."
      }
     },
     "event": {
@@ -822,7 +822,7 @@
     },
     "iCalUID": {
      "type": "string",
-     "description": "Event unique identifier as defined in RFC5545. It is used to uniquely identify events accross calendaring systems and must be supplied when importing events via the import method.\nNote that the icalUID and the id are not identical and only one of them should be supplied at event creation time. One difference in their semantics is that in recurring events, all occurrences of one event have different ids while they all share the same icalUIDs.",
+     "description": "Event unique identifier as defined in RFC5545. It is used to uniquely identify events across calendaring systems and must be supplied when importing events via the import method.\nNote that the icalUID and the id are not identical and only one of them should be supplied at event creation time. One difference in their semantics is that in recurring events, all occurrences of one event have different ids while they all share the same icalUIDs.",
      "annotations": {
       "required": [
        "calendar.events.import"

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -4,12 +4,12 @@ from dateutil.tz import tzlocal
 
 minimal_event = {
                     'e': datetime(2019, 1, 8, 15, 15, tzinfo=tzlocal()),
-                    'id': 'minimial_event',
+                    'id': 'minimal_event',
                     's': datetime(2019, 1, 8, 14, 15, tzinfo=tzlocal())
                  }
 minimal_event_overlapping = {
                     'e': datetime(2019, 1, 8, 16, 15, tzinfo=tzlocal()),
-                    'id': 'minimial_event_overlapping',
+                    'id': 'minimal_event_overlapping',
                     's': datetime(2019, 1, 8, 14, 30, tzinfo=tzlocal())
                  }
 minimal_event_nonoverlapping = {


### PR DESCRIPTION
Found via `codespell -S htmlcov`