### PR TITLE
Update Python version for tox

### DIFF
--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from datetime import datetime
 from itertools import chain
-from typing import List
 
 from dateutil.parser import isoparse, parse
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py3{8,9,10,11}
 
 [testenv]
 usedevelop=true


### PR DESCRIPTION
List of changes:
- remove unsupported Python <3.8
- add Python >= 3.8 for tox
- fix issue raise by flake8