### PR TITLE
build: change supported Python versions to 3.8, 3.9, 3.10, 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='gcalcli',
       license='MIT',
       packages=['gcalcli'],
       data_files=[('share/man/man1', ['docs/man1/gcalcli.1'])],
-      python_requires='>=3',
+      python_requires='>=3.8',
       install_requires=[
           'python-dateutil',
           'google-api-python-client>=1.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py38,py39,py310,py311
 
 [testenv]
 usedevelop=true


### PR DESCRIPTION
These are the released versions of Python that are currently
supported by the Python core developers.

https://devguide.python.org/versions/

Might be a few flake8 errors on this version. This is to be corrected
by a subsequent pull request that will fix import orders.
