### PR TITLE
fix event list: configure all page queries, not just the first one

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1026,8 +1026,18 @@ class GoogleCalendarInterface:
 
         return selected
 
-    def _GetAllEvents(self, cal, events, end):
-
+    def _GetAllEvents(self, cal, start, end, search_text):
+        events = self._retry_with_backoff(
+                     self.get_events()
+                         .list(
+                             calendarId=cal['id'],
+                             timeMin=start.isoformat() if start else None,
+                             timeMax=end.isoformat() if end else None,
+                             q=search_text if search_text else None,
+                             singleEvents=True
+                         )
+                )
+      
         event_list = []
 
         while 1:
@@ -1079,6 +1089,10 @@ class GoogleCalendarInterface:
                              self.get_events()
                                  .list(
                                      calendarId=cal['id'],
+                                     timeMin=start.isoformat() if start else None,
+                                     timeMax=end.isoformat() if end else None,
+                                     q=search_text if search_text else None,
+                                     singleEvents=True,
                                      pageToken=pageToken
                                  )
                          )
@@ -1091,17 +1105,7 @@ class GoogleCalendarInterface:
 
         event_list = []
         for cal in self.cals:
-            events = self._retry_with_backoff(
-                         self.get_events()
-                             .list(
-                                 calendarId=cal['id'],
-                                 timeMin=start.isoformat() if start else None,
-                                 timeMax=end.isoformat() if end else None,
-                                 q=search_text if search_text else None,
-                                 singleEvents=True
-                             )
-                    )
-            event_list.extend(self._GetAllEvents(cal, events, end))
+            event_list.extend(self._GetAllEvents(cal, start, end, search_text))
 
         event_list.sort(key=lambda x: x['s'])
 


### PR DESCRIPTION
When a large list of events was obtained, only the first query was correct. Subsequent queries used default parameters, so the resulting list had the earliest events of the calendar, etc. (The Google API may have changed since the affected code was written.)

An illustration:

```sh
$ pip install --upgrade git+https://github.com/insanum/gcalcli
$ gcalcli agenda --tsv 2021-01-01 2021-12-31 | head -n3 | cut -f1-4
start_date	start_time	end_date	end_time
2012-05-17	21:00	2012-05-17	22:00  # the very first event in my default calendar
2012-07-17	11:00	2012-07-17	12:00

$ pip install --upgrade git+https://github.com/kbulygin/gcalcli
$ gcalcli agenda --tsv 2021-01-01 2021-12-31 | head -n3 | cut -f1-4
start_date	start_time	end_date	end_time
2020-12-31	20:00	2021-01-01	03:00  # correct
2021-01-01	00:47	2021-01-01	00:47
```