### PR TITLE
docs: README.md: source install instructions use pip to avoid google namespace package differences

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ pip install gcalcli
 ```sh
 git clone https://github.com/insanum/gcalcli.git
 cd gcalcli
-python setup.py install
+python -m pip install .
 ```
 
 ### Install optional package


### PR DESCRIPTION
Avoids this issue: https://github.com/protocolbuffers/protobuf/issues/7877#issuecomment-691371728

Summary: google packages are mixing "native namespace packages" and "eggs that internally use pkg_resources-style packages", causing `ImportError` when people install from source using `python setup.py install`; instead, people should install from source with `python -m pip install`.  The google packages are running afoul of the "Warning" from https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#creating-a-namespace-package .
