### PR TITLE
Replace deprecated oauth2client with google-auth

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -5,7 +5,6 @@ from gcalcli import utils
 from gcalcli.details import DETAILS
 from gcalcli.deprecations import parser_allow_deprecated, DeprecatedStoreTrue
 from gcalcli.printer import valid_color_name
-from oauth2client import tools
 from shutil import get_terminal_size
 import copy as _copy
 import datetime
@@ -244,8 +243,7 @@ def get_argument_parser():
     parser = argparse.ArgumentParser(
             description='Google Calendar Command Line Interface',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            fromfile_prefix_chars='@',
-            parents=[tools.argparser])
+            fromfile_prefix_chars='@')
 
     parser.add_argument(
             '--version', action='version', version='%%(prog)s %s (%s)' %

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -13,7 +13,7 @@ from gcalcli.utils import is_all_day
 FMT_DATE = '%Y-%m-%d'
 FMT_TIME = '%H:%M'
 TODAY = datetime.now().date()
-ACTION_DEFAULT = "patch"
+ACTION_DEFAULT = 'patch'
 
 URL_PROPS = OrderedDict([('html_link', 'htmlLink'),
                          ('hangout_link', 'hangoutLink')])

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -35,9 +35,9 @@ from dateutil.tz import tzlocal
 from dateutil.parser import parse
 from apiclient.discovery import build
 from apiclient.errors import HttpError
-from oauth2client.file import Storage
-from oauth2client.client import OAuth2WebServerFlow
-from oauth2client import tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from google.auth.transport.requests import Request
 from collections import namedtuple
 
 EventTitle = namedtuple('EventTitle', ['title', 'color'])
@@ -54,7 +54,7 @@ class GoogleCalendarInterface:
     agenda_length = 5
     conflicts_lookahead_days = 30
     max_retries = 5
-    auth_http = None
+    credentials = None
     cal_service = None
 
     ACCESS_OWNER = 'owner'
@@ -131,39 +131,46 @@ class GoogleCalendarInterface:
         return None
 
     def _google_auth(self):
-        from argparse import Namespace
-        if not self.auth_http:
+        if not self.credentials:
             if self.options['config_folder']:
-                storage = Storage(
-                        os.path.expanduser(
-                                '%s/oauth' % self.options['config_folder']
-                        )
+                oauth_filepath = os.path.expanduser(
+                    '%s/oauth' % self.options['config_folder']
                 )
             else:
-                storage = Storage(os.path.expanduser('~/.gcalcli_oauth'))
-            credentials = storage.get()
-
-            if credentials is None or credentials.invalid:
-                credentials = tools.run_flow(
-                    OAuth2WebServerFlow(
-                        client_id=self.options['client_id'],
-                        client_secret=self.options['client_secret'],
-                        scope=['https://www.googleapis.com/auth/calendar'],
-                        user_agent=__program__ + '/' + __version__
-                    ),
-                    storage,
-                    Namespace(**self.options)
+                oauth_filepath = os.path.expanduser('~/.gcalcli_oauth')
+            if os.path.exists(oauth_filepath):
+                with open(oauth_filepath, 'rb') as gcalcli_oauth:
+                    credentials = pickle.load(gcalcli_oauth)
+            else:
+                flow = InstalledAppFlow.from_client_config(
+                    client_config={
+                        "installed": {
+                            "client_id": self.options['client_id'],
+                            "client_secret": self.options['client_secret'],
+                            "auth_uri":"https://accounts.google.com/o/oauth2/auth",
+                            "token_uri":"https://oauth2.googleapis.com/token",
+                            "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
+                            "redirect_uris":["http://localhost"]
+                        }
+                    },
+                    scopes=['https://www.googleapis.com/auth/calendar']
                 )
+                credentials = flow.run_local_server()
+                with open(oauth_filepath, 'wb') as gcalcli_oauth:
+                    pickle.dump(credentials, gcalcli_oauth)
 
-            self.auth_http = credentials.authorize(httplib2.Http())
+            if credentials.expired:
+                credentials.refresh(Request())
 
-        return self.auth_http
+            self.credentials = credentials
+
+        return self.credentials
 
     def get_cal_service(self):
         if not self.cal_service:
             self.cal_service = build(serviceName='calendar',
                                      version='v3',
-                                     http=self._google_auth())
+                                     credentials=self._google_auth())
 
         return self.cal_service
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -608,7 +608,7 @@ class GoogleCalendarInterface:
             for handler in handlers:
                 row.extend(handler.get(event))
 
-            output = ('\t'.join(row)).replace('\n', '''\\n''')
+            output = ('\t'.join(row)).replace('\n', r'\n')
             print(output)
 
     def _PrintEvent(self, event, prefix):
@@ -964,7 +964,7 @@ class GoogleCalendarInterface:
                 while True:
                     r = get_input(
                             self.printer, "Enter a valid reminder or '.' to"
-                                          "end: ", REMINDER
+                                          'end: ', REMINDER
                     )
                     if r == '.':
                         break
@@ -1169,11 +1169,11 @@ class GoogleCalendarInterface:
         event_list = [e for e in event_list
                       if (utils.get_time_from_str(e['updated']) >=
                           last_updated_datetime)]
-        print("Updates since:",
+        print('Updates since:',
               last_updated_datetime,
-              "events starting",
+              'events starting',
               start,
-              "until",
+              'until',
               end)
         return self._iterate_events(start, event_list, year_date=False)
 
@@ -1186,7 +1186,7 @@ class GoogleCalendarInterface:
 
         event_list = self._search_for_events(start, end, search_text)
         show_conflicts = ShowConflicts(
-                            lambda e: self._PrintEvent(e, "\t !!! Conflict: "))
+                            lambda e: self._PrintEvent(e, '\t !!! Conflict: '))
 
         return self._iterate_events(start,
                                     event_list,
@@ -1211,7 +1211,7 @@ class GoogleCalendarInterface:
         cal = self.cals[0]
 
         for row in reader:
-            action = row.get("action", ACTION_DEFAULT)
+            action = row.get('action', ACTION_DEFAULT)
             if action not in ACTIONS:
                 raise GcalcliError('Action "{}" not supported.'.format(action))
 
@@ -1321,7 +1321,7 @@ class GoogleCalendarInterface:
             try:
                 self.cals = [cals_with_write_perms[int(val)]]
             except IndexError:
-                raise GcalcliError('The entered number doesn\'t appear on the '
+                raise GcalcliError("The entered number doesn't appear on the "
                                    'list above\n')
 
         event = {}

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -43,6 +43,7 @@ from collections import namedtuple
 EventTitle = namedtuple('EventTitle', ['title', 'color'])
 
 CONFERENCE_DATA_VERSION = 1
+PRINTER = Printer()
 
 
 class GoogleCalendarInterface:
@@ -63,7 +64,7 @@ class GoogleCalendarInterface:
 
     UNIWIDTH = {'W': 2, 'F': 2, 'N': 1, 'Na': 1, 'H': 1, 'A': 1}
 
-    def __init__(self, cal_names=[], printer=Printer(), **options):
+    def __init__(self, cal_names=(), printer=PRINTER, **options):
         self.cals = []
         self.printer = printer
         self.options = options

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='gcalcli',
           'python-dateutil',
           'google-api-python-client>=1.4',
           'httplib2',
-          'oauth2client',
+          'google_auth_oauthlib',
           'parsedatetime',
       ],
       extras_require={


### PR DESCRIPTION
This cannot be merged because of the later restructuring of the code.

Nonetheless, with this at least basic functionality works with current day libraries.