### PR TITLE
Tooling: drop flake8, configure ruff and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,16 @@ gcalcli = "gcalcli.cli:main"
 [tool.distutils.bdist_wheel]
 universal = true
 
-[tool.isort]
-profile = "google"
-force_single_line = false
-float_to_top = true
-combine_star = true
-py_version = 3
+[tool.ruff]
+line-length = 80
+
+[tool.ruff.lint]
+# Enable Errors, Warnings, Flakes
+select = ["E", "W", "F"]
+
+[tool.ruff.format]
+# Permit mixed quote style, project currently uses a mix of both.
+quote-style = "preserve"
 
 [[tool.mypy.overrides]]
 module = ["gcalcli"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[flake8]
-import-order-style = google
-exclude =
-    .git,
-    __pycache__,
-    venv,
-    .env,
-    .tox,
-    .venv

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ usedevelop=true
 deps = pytest
        pytest-cov
        coverage
-       flake8
+       ruff
        vobject
 
 commands=py.test -vv --cov=./gcalcli --pyargs tests {posargs}
          coverage html
-         flake8
+         ruff check


### PR DESCRIPTION
Why: Ruff is more powerful, flexible, and faster than flake8, with better defaults and integrated formatter.

The editorconfig file is technically unrelated (and actually ignored by ruff currently :frowning_face:), but helps ensure that editors and formatters aren't fighting each other over the style defaults.