### PR TITLE
Fix import and agendaupdate to handle encoding errors more gracefully

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 v4.4.0
-  * Fix lots of bugs by switching from deprecaetd oauth2client to
+  * Fix lots of bugs by switching from deprecated oauth2client to
     google_auth_oauthlib
+  * Handle encoding/decoding errors more gracefully by replacing with
+    placeholder chars instead of blowing up
   * Fix `--lineart` option failing with unicode errors
   * `quick` command now prompts for which calendar to use when ambiguous
   * Fix --nodeclined option failing on events with aliased email

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -318,7 +318,10 @@ def get_argument_parser():
             help='update calendar from agenda TSV file',
             description='Update calendar from agenda TSV file.')
     agendaupdate.add_argument(
-        'file', type=argparse.FileType('r'), nargs='?', default=sys.stdin)
+        'file',
+        type=argparse.FileType('r', errors='replace'),
+        nargs='?',
+        default=sys.stdin)
 
     sub.add_parser(
             'updates',
@@ -395,7 +398,10 @@ def get_argument_parser():
             'must be specified.  Reads from stdin when no file argument is '
             'provided.')
     _import.add_argument(
-            'file', type=argparse.FileType('r'), nargs='?', default=None)
+            'file',
+            type=argparse.FileType('r', errors='replace'),
+            nargs='?',
+            default=None)
     _import.add_argument(
             '--verbose', '-v', action='count', help='Be verbose on imports')
     _import.add_argument(

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from json import load
 import re
 
-import pytest
 from dateutil.tz import tzutc
 
 from gcalcli.argparsers import (
@@ -274,14 +273,11 @@ def test_modify_event(PatchedGCalI):
             gcal._edit_event, opts.text, opts.start, opts.end) == 0
 
 
-@pytest.mark.skipif(
-        os.name == 'nt',
-        reason='Known unicode encode/decode issue, see insanum/gcalcli#387.')
 def test_import(PatchedGCalI):
     cal_names = parse_cal_names(['jcrowgey@uw.edu'])
     gcal = PatchedGCalI(cal_names=cal_names, default_reminders=True)
     vcal_path = TEST_DATA_DIR + '/vv.txt'
-    assert gcal.ImportICS(icsFile=open(vcal_path))
+    assert gcal.ImportICS(icsFile=open(vcal_path, errors='replace'))
 
 
 def test_parse_reminder():


### PR DESCRIPTION
Configures file arguments with errors='replace' so that if they encounter characters they can't encode/decode they'll just replace them with a replacement marker such as '?' instead of raising an exception.

Fixes #387 (probably)