### PR TITLE
Fix event list lookups returning incorrect events due to pagination

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ v4.4.0
   * Fix `--lineart` option failing with unicode errors
   * `quick` command now prompts for which calendar to use when ambiguous
   * Fix `--nodeclined` option failing on events with aliased email
+  * Fix event list commands like `agenda` returning some events that don't
+    actually match their search criteria due to pagination bug (kbulygin)
   * `add` command now supports `--end` as an alternative to `--duration`
     (michaelPotter)
 


### PR DESCRIPTION
Ensures that requests using pageToken preserve the same parameters as the initial request to avoid returning non-matching items after the first page.

Fixes issue mentioned in PR #664.