### PR TITLE
tooling: source gcalcli version from setuptools-scm instead of py string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 venv/
 htmlcov/
 
+/gcalcli/_version.py
 gcalcli.egg-info
 
 .coverage

--- a/gcalcli/__init__.py
+++ b/gcalcli/__init__.py
@@ -1,3 +1,9 @@
+try:
+    from ._version import __version__ as __version__
+except ImportError:
+    import warnings
+    warnings.warn('Failed to load __version__ from setuptools-scm')
+    __version__ = '__unknown__'
+
 __program__ = 'gcalcli'
-__version__ = 'v4.4.0'
 __author__ = 'Eric Davis, Brian Hartvigsen, Joshua Crowgey'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -53,8 +53,8 @@ packages = ["gcalcli"]
 [tool.setuptools.data-files]
 "share/man/man1" = ["docs/man1/gcalcli.1"]
 
-[tool.setuptools.dynamic]
-version = { attr = "gcalcli.__version__" }
+[tool.setuptools_scm]
+version_file = "gcalcli/_version.py"
 
 [project.scripts]
 gcalcli = "gcalcli.cli:main"


### PR DESCRIPTION
Magically loads versions from git tags, with suffixes on dev builds that don't come from an exact tag commit.