### PR TITLE
Bump requires-python to ">= 3.10"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
-          - "3.8"
         os:
           - ubuntu-latest
           - macos-latest

--- a/gcalcli/_types.py
+++ b/gcalcli/_types.py
@@ -4,7 +4,7 @@
 # must have underscore so as not to shadow stdlib types.py
 
 from datetime import datetime
-from typing import Any, Dict, List, TYPE_CHECKING, TypedDict
+from typing import Any, TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from googleapiclient._apis.calendar.v3.schemas import (  # type: ignore
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     # XXX: having all_cals available as an invariant would be better than
     # setting total=False
     class Cache(TypedDict, total=False):
-        all_cals: List[CalendarListEntry]
+        all_cals: list[CalendarListEntry]
 else:
-    CalendarListEntry = Dict[str, Any]
-    Event = Dict[str, Any]
-    Cache = Dict[str, Any]
+    CalendarListEntry = dict[str, Any]
+    Event = dict[str, Any]
+    Cache = dict[str, Any]

--- a/gcalcli/conflicts.py
+++ b/gcalcli/conflicts.py
@@ -1,10 +1,8 @@
-from typing import List  # python3.9: can just use `list`
-
 from ._types import Event
 
 
 class ShowConflicts:
-    active_events: List[Event] = []
+    active_events: list[Event] = []
 
     def __init__(self, show):
         if show:

--- a/gcalcli/deprecations.py
+++ b/gcalcli/deprecations.py
@@ -1,6 +1,6 @@
 import argparse
 import functools
-from typing import Any, Dict
+from typing import Any
 
 from .printer import Printer, valid_color_name
 
@@ -69,7 +69,7 @@ BASE_OPTS = {'program': {'type': str,
                         'action': DeprecatedStoreTrue}}
 
 
-OPTIONS: Dict[str, Dict[str, Any]] = {
+OPTIONS: dict[str, dict[str, Any]] = {
     'program': {
         "--client_id": {'default': None},
         "--client_secret": {'default': None},

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from datetime import datetime
 from itertools import chain
-from typing import List  # python3.9: can just use `list`
 
 from dateutil.parser import isoparse, parse
 
@@ -33,7 +32,7 @@ class Handler:
     """Handler for a specific detail of an event."""
 
     # list of strings for fieldnames provided by this object
-    fieldnames: List[str] = []
+    fieldnames: list[str] = []
 
     @classmethod
     def get(cls, event):

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -10,7 +10,7 @@ import shlex
 import sys
 import textwrap
 import time
-from typing import Iterable, List
+from typing import Iterable
 from unicodedata import east_asian_width
 
 import googleapiclient.http
@@ -47,7 +47,7 @@ PRINTER = Printer()
 class GoogleCalendarInterface:
 
     cache: Cache = {}
-    all_cals: List[CalendarListEntry] = []
+    all_cals: list[CalendarListEntry] = []
     now = datetime.now(tzlocal())
     agenda_length = 5
     conflicts_lookahead_days = 30

--- a/gcalcli/ics.py
+++ b/gcalcli/ics.py
@@ -3,12 +3,12 @@
 import importlib.util
 import io
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from gcalcli.printer import Printer
 from gcalcli.utils import localize_datetime
 
-EventBody = Dict[str, Any]
+EventBody = dict[str, Any]
 
 
 def has_vobject_support() -> bool:
@@ -17,10 +17,10 @@ def has_vobject_support() -> bool:
 
 def get_events(
     ics: io.TextIOBase, verbose: bool, default_tz: str, printer: Printer
-) -> List[Optional[EventBody]]:
+) -> list[Optional[EventBody]]:
     import vobject
 
-    events: List[Optional[EventBody]] = []
+    events: list[Optional[EventBody]] = []
     for v in vobject.readComponents(ics):
         events.extend(
             CreateEventFromVOBJ(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "gcalcli"
 dynamic = ["version"]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
@@ -26,12 +26,12 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "python-dateutil",
-  "google-api-python-client>=1.4",
-  "httplib2",
-  "google_auth_oauthlib",
-  "parsedatetime",
   "argcomplete",
+  "google-api-python-client>=1.4",
+  "google_auth_oauthlib",
+  "httplib2",
+  "parsedatetime",
+  "python-dateutil",
   # dev dependencies
   "google-api-python-client-stubs",
   "types-python-dateutil",
@@ -58,9 +58,6 @@ version_file = "gcalcli/_version.py"
 
 [project.scripts]
 gcalcli = "gcalcli.cli:main"
-
-[tool.distutils.bdist_wheel]
-universal = true
 
 [tool.ruff]
 line-length = 80

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-envlist = lint, type, py3{8,9,10,11,12}, cli
+envlist = lint, type, py3{10,11,12}, cli
 
 [testenv]
 usedevelop=true
@@ -37,6 +37,4 @@ commands =
 python =
     3.12 = py312, lint, type, cli
     3.11 = py311
-    3.10 = py310
-    3.9 = py39
-    3.8 = py38, type
+    3.10 = py310, type


### PR DESCRIPTION
Bump `project.requires-python`, remove py3.8 and py3.9 from test matrix, and clean up compatibility cruft for older python versions.