### PR TITLE
chore: move dev deps into `project.optional-dependencies`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,4 +44,8 @@ git submodule update --init
 tox
 ```
 
+NOTE: You'll also want to install the "dev" extra in any development environment you're using
+that's not managed by tox (by changing install commands `gcalcli`->`gcalcli[dev]` or
+`.`->`.[dev]`).
+
 See [tests/README.md](tests/README.md) for more info on the tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,6 @@ dependencies = [
   "parsedatetime",
   "python-dateutil",
   "truststore",
-  # dev dependencies
-  "google-api-python-client-stubs",
-  "types-python-dateutil",
-  "types-requests",
-  "types-vobject",
 ]
 
 [project.urls]
@@ -47,6 +42,12 @@ Changelog = "https://github.com/insanum/gcalcli/blob/HEAD/ChangeLog"
 
 [project.optional-dependencies]
 vobject = ["vobject"]
+dev = [
+  "google-api-python-client-stubs",
+  "types-python-dateutil",
+  "types-requests",
+  "types-vobject",
+]
 
 [tool.setuptools]
 packages = ["gcalcli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,13 @@ Issues = "https://github.com/insanum/gcalcli/issues"
 Changelog = "https://github.com/insanum/gcalcli/blob/HEAD/ChangeLog"
 
 [project.optional-dependencies]
-vobject = ["vobject"]
 dev = [
   "google-api-python-client-stubs",
   "types-python-dateutil",
   "types-requests",
   "types-vobject",
 ]
+vobject = ["vobject"]
 
 [tool.setuptools]
 packages = ["gcalcli"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ requires =
 envlist = lint, type, py3{10,11,12}, cli
 
 [testenv]
-usedevelop=true
+usedevelop = true
 deps = pytest
        pytest-cov
        coverage
        vobject
+extras = dev
 
 commands=py.test -vv --cov=./gcalcli --pyargs tests {posargs}
          coverage html


### PR DESCRIPTION
While doing [4.4.0 release build](https://github.com/Homebrew/homebrew-core/pull/182881), seeing bunch of dev deps pulled in, thus updating the pyproject.toml.