### PR TITLE
gh-actions: Fix on.pull_request.paths-ignore patterns

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '/*.md'
-      - '/ChangeLog'
-      - '/LICENSE'
-      - 'docs/**'
+      - '*.md'
+      - ChangeLog
+      - LICENSE
+      - docs/**
 
 permissions:
   contents: read


### PR DESCRIPTION
All patterns start from the repository's root and patterns that start with '/' won't match anything. See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths.