### PR TITLE
feat: print an error message when ~/.gcalcli_oauth deserialization fails

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -132,7 +132,16 @@ class GoogleCalendarInterface:
             oauth_filepath = os.path.expanduser('~/.gcalcli_oauth')
         if os.path.exists(oauth_filepath):
             with open(oauth_filepath, 'rb') as gcalcli_oauth:
-                self.credentials = pickle.load(gcalcli_oauth)
+                try:
+                    self.credentials = pickle.load(gcalcli_oauth)
+                except pickle.UnpicklingError as e:
+                    self.printer.err_msg(
+                        f"Couldn't parse {oauth_filepath}.\n"
+                        "The file may be corrupt or be incompatible with this "
+                        "version of gcalcli. It probably has to be removed and "
+                        "provisioning done again.\n"
+                    )
+                    raise e
 
         if not self.credentials:
             # No cached credentials, start auth flow


### PR DESCRIPTION
At the moment, only a backtrace is printed and it doesn't make what's going on obvious.

This is especially important now as the migration from oauth2client to google-auth comes with a format change for this file and anyone who had been using gcalcli successfully before is likely to encounter this error.

I've tested this change the following way in a container:

```
# echo x > .gcalcli_oauth
# gcalcli list
Couldn't parse /root/.gcalcli_oauth.
The file may be corrupt or be incompatible with this version of gcalcli. It probably has to be removed and provisioning done again.
[backtrace]
```

This doesn't cover the file being empty but a) this is quite unlikely to happen, b) the cause would be completely different; moreover the exception is quite clear: `EOFError: Ran out of input`

Helps with #691.