### PR TITLE
Migrate data files like ~/.gcalcli_oauth into standard data file paths

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ v4.5.0
   * Respect locally-installed certificates (ajkessel)
   * Re-add a `--noauth_local_server` to provide instructions for authenticating
     from a remote system using port forwarding
+  * Migrate data files like ~/.gcalcli_oauth into standard data file paths
+    (with fallback to migrate detected files into the new paths)
 
 v4.4.0
   * Fix lots of bugs by switching from deprecated oauth2client to

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -4,6 +4,7 @@ import argparse
 import copy as _copy
 import datetime
 import locale
+import pathlib
 import sys
 from shutil import get_terminal_size
 
@@ -33,9 +34,12 @@ PROGRAM_OPTIONS = {
     },
     '--config-folder': {
         'default': None,
-        'type': str,
-        'help': 'Optional directory to load/store all configuration '
-        'information',
+        'type': pathlib.Path,
+        'help': 'Optional directory used to load config files. If unset, '
+        'gcalclirc will be read from ~/.gcalclirc instead of '
+        'CONFIG_FOLDER/gcalclirc. Note: this path is also used to determine '
+        'fallback paths to check for cache/oauth files to be migrated into '
+        'their proper data dir paths.',
     },
     '--noincluderc': {
         'action': 'store_false',

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -96,7 +96,7 @@ def main():
             # We want .gcalclirc to be sourced before any other --flagfile
             # params since we may be told to use a specific config folder, we
             # need to store generated argv in temp variable
-            tmp_argv = ['@%s' % gcalclirc, ] + argv
+            tmp_argv = [f'@{gcalclirc}'] + argv
         else:
             tmp_argv = argv
 
@@ -107,17 +107,18 @@ def main():
         sys.exit(1)
 
     if parsed_args.config_folder:
-        if not os.path.exists(os.path.expanduser(parsed_args.config_folder)):
-            os.makedirs(os.path.expanduser(parsed_args.config_folder))
-        if os.path.exists(os.path.expanduser('%s/gcalclirc' %
-                                             parsed_args.config_folder)):
-            rc_path = ['@%s/gcalclirc' % parsed_args.config_folder, ]
-            if not parsed_args.includeRc:
-                tmp_argv = rc_path + argv
-            else:
-                tmp_argv = rc_path + tmp_argv
+        parsed_args.config_folder = parsed_args.config_folder.expanduser()
+        gcalclirc_path = parsed_args.config_folder.joinpath('gcalclirc')
+        if gcalclirc_path.exists():
+            # TODO: Should this precedence be flipped to:
+            # ['@~/.gcalclirc', '@CONFIG_FOLDER/gcalclirc', ...]?
+            tmp_argv = [f'@{gcalclirc_path}'] + (
+                tmp_argv if parsed_args.includeRc else argv
+            )
 
         (parsed_args, unparsed) = parser.parse_known_args(tmp_argv)
+        if parsed_args.config_folder:
+            parsed_args.config_folder = parsed_args.config_folder.expanduser()
 
     printer = Printer(
             conky=parsed_args.conky, use_color=parsed_args.color,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "google_auth_oauthlib",
   "httplib2",
   "parsedatetime",
+  "platformdirs",
   "python-dateutil",
   "truststore",
 ]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,7 @@ def test_legacy_certs(tmpdir, gcali_patches, patched_google_reauth):
     tmpdir = pathlib.Path(tmpdir)
     oauth_filepath = tmpdir / 'oauth'
     shutil.copy(TEST_DATA_DIR / 'legacy_oauth_creds.json', oauth_filepath)
-    gcal = gcali_patches.GCalI(config_folder=tmpdir, refresh_cache=False)
+    gcal = gcali_patches.GCalI(data_path=tmpdir, refresh_cache=False)
     assert isinstance(
         gcal.get_cal_service(), googleapiclient.discovery.Resource
     )


### PR DESCRIPTION
Uses platformdirs to determine appropriate data file paths for each platform (e.g. under ~/.local/share/ or ~/Library/Application Support/).

Fixes #640.