### PR TITLE
Add support for parsing config.toml from config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ gcalcli.egg-info
 .pytest_cache?
 .tox
 
+.python-version
 *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include ChangeLog
 include README.md
 exclude .git*
 
+graft data
 graft docs
 prune .github

--- a/data/config-schema.json
+++ b/data/config-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gcalcli config",
+  "type": "object",
+  "description": "User configuration for gcalcli command-line tool. See https://pypi.org/project/gcalcli/.",
+  "properties": {
+    "calendars": {
+      "type": "object",
+      "description": "Settings about the set of calendars gcalcli operates on",
+      "properties": {
+        "default-calendar": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Calendar(s) to use as default for certain commands when no explicit target calendar is otherwise specified"
+        }
+      }
+    }
+  }
+}

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -4,17 +4,15 @@ import argparse
 import copy as _copy
 import datetime
 import locale
-import os
 import pathlib
 import sys
 from shutil import get_terminal_size
 
 import argcomplete  # type: ignore
-import platformdirs
 
 import gcalcli
 
-from . import utils
+from . import env, utils
 from .deprecations import DeprecatedStoreTrue, parser_allow_deprecated
 from .details import DETAILS
 from .printer import valid_color_name
@@ -35,7 +33,7 @@ PROGRAM_OPTIONS = {
         'is no longer supported.',
     },
     '--config-folder': {
-        'default': os.environ.get('GCALCLI_CONFIG'),
+        'default': env.default_config_dir(),
         'type': pathlib.Path,
         'help': 'Optional directory used to load config files. Deprecated: '
         'prefer $GCALCLI_CONFIG.',
@@ -312,9 +310,7 @@ configuration:
 
 @parser_allow_deprecated(name='program')
 def get_argument_parser():
-    config_dir = (
-        os.environ.get('GCALCLI_CONFIG') or platformdirs.user_config_dir()
-    )
+    config_dir = env.default_config_dir()
     rc_paths = [pathlib.Path(config_dir).joinpath('gcalclirc')]
     legacy_rc_path = pathlib.Path.home().joinpath('.gcalclirc')
     if legacy_rc_path.exists():

--- a/gcalcli/env.py
+++ b/gcalcli/env.py
@@ -1,0 +1,16 @@
+import os
+import pathlib
+import platformdirs
+
+from . import __program__
+
+
+def default_data_dir() -> pathlib.Path:
+    return platformdirs.user_data_path(__program__)
+
+
+def default_config_dir() -> pathlib.Path:
+    return pathlib.Path(
+        os.environ.get('GCALCLI_CONFIG')
+        or platformdirs.user_config_dir(__program__)
+    )

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -22,9 +22,8 @@ from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzlocal
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-import platformdirs
 
-from . import __program__, actions, auth, ics, utils
+from . import actions, auth, env, ics, utils
 from ._types import Cache, CalendarListEntry, Event
 from .actions import ACTIONS
 from .conflicts import ShowConflicts
@@ -134,13 +133,9 @@ class GoogleCalendarInterface:
 
         return None
 
-    @staticmethod
-    def default_data_dir() -> pathlib.Path:
-        return platformdirs.user_data_path(__program__)
-
     @functools.cache
     def data_file_path(self, name: str) -> pathlib.Path:
-        path = self.default_data_dir().joinpath(name)
+        path = env.default_data_dir().joinpath(name)
         explicit_config: pathlib.Path = self.options['config_folder']
         if explicit_config:
             legacy_path = explicit_config.joinpath(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "parsedatetime",
   "platformdirs",
   "python-dateutil",
+  "toml; python_version < '3.11'",
   "truststore",
 ]
 
@@ -46,6 +47,7 @@ dev = [
   "google-api-python-client-stubs",
   "types-python-dateutil",
   "types-requests",
+  "types-toml; python_version < '3.11'",
   "types-vobject",
 ]
 vobject = ["vobject"]


### PR DESCRIPTION
Initially this just supports a single config key, calendars.default-calendar.

Fixes #416.