### PR TITLE
New config.toml: rename default-calendar->default-calendars, add note config.toml file into --help

### DIFF
--- a/data/config-schema.json
+++ b/data/config-schema.json
@@ -8,7 +8,7 @@
       "type": "object",
       "description": "Settings about the set of calendars gcalcli operates on",
       "properties": {
-        "default-calendar": {
+        "default-calendars": {
           "type": "array",
           "items": { "type": "string" },
           "description": "Calendar(s) to use as default for certain commands when no explicit target calendar is otherwise specified"

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -120,7 +120,7 @@ def main():
         with config_filepath.open('rb') as config_file:
             config = tomllib.load(config_file)
             opts_from_config.defaultCalendar = config.get('calendars', {}).get(
-                'default-calendar', []
+                'default-calendars', []
             )
 
     if parsed_args.config_folder:


### PR DESCRIPTION
Renames config value, updates --help to explain the config, and also tweaks the other config paths reported in --help to be a bit shorter and more readable.

Follow-up from #744, helps with #416.
