### PR TITLE
Improve handling of --calendar and --noincluderc args

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,10 @@ v4.5.0
   * Add `init` command to explicitly request auth setup/refresh
   * Add support for config.toml file and `gcalcli config edit` command
   * Add support for `gcalcli util config-schema|reset-cache` commands
+  * Behavior change: `--noincluderc` now skips gcalclirc files unconditionally,
+    w/ or w/o --config-folder
+    - POSSIBLE ACTION REQUIRED: Use `@path/to/gcalclirc` explicitly if it stops
+      reading an rc file you needed
   * Respect locally-installed certificates (ajkessel)
   * Re-add a `--noauth_local_server` to provide instructions for authenticating
     from a remote system using port forwarding

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -17,7 +17,6 @@ from .deprecations import DeprecatedStoreTrue, parser_allow_deprecated
 from .details import DETAILS
 from .printer import valid_color_name
 
-
 PROGRAM_OPTIONS = {
     '--client-id': {'default': None, 'type': str, 'help': 'API client_id'},
     '--client-secret': {
@@ -97,7 +96,6 @@ PROGRAM_OPTIONS = {
 
 
 class DetailsAction(argparse._AppendAction):
-
     def __call__(self, parser, namespace, value, option_string=None):
         details = _copy.copy(getattr(namespace, self.dest, {}))
 
@@ -119,7 +117,8 @@ def validwidth(value):
 def validreminder(value):
     if not utils.parse_reminder(value):
         raise argparse.ArgumentTypeError(
-                'Not a valid reminder string: %s' % value)
+            'Not a valid reminder string: %s' % value
+        )
     else:
         return value
 
@@ -127,9 +126,12 @@ def validreminder(value):
 def get_details_parser():
     details_parser = argparse.ArgumentParser(add_help=False)
     details_parser.add_argument(
-            '--details', default={}, action=DetailsAction,
-            choices=DETAILS + ['all'],
-            help='Which parts to display, can be: ' + ', '.join(DETAILS))
+        '--details',
+        default={},
+        action=DetailsAction,
+        choices=DETAILS + ['all'],
+        help='Which parts to display, can be: ' + ', '.join(DETAILS),
+    )
     return details_parser
 
 
@@ -182,28 +184,55 @@ def get_calendars_parser(nargs_multiple: bool) -> argparse.ArgumentParser:
 def get_output_parser(parents=[]):
     output_parser = argparse.ArgumentParser(add_help=False, parents=parents)
     output_parser.add_argument(
-            '--tsv', action='store_true', dest='tsv', default=False,
-            help='Use Tab Separated Value output')
+        '--tsv',
+        action='store_true',
+        dest='tsv',
+        default=False,
+        help='Use Tab Separated Value output',
+    )
     output_parser.add_argument(
-            '--nostarted', action='store_true', dest='ignore_started',
-            default=False, help='Hide events that have started')
+        '--nostarted',
+        action='store_true',
+        dest='ignore_started',
+        default=False,
+        help='Hide events that have started',
+    )
     output_parser.add_argument(
-            '--nodeclined', action='store_true', dest='ignore_declined',
-            default=False, help='Hide events that have been declined')
+        '--nodeclined',
+        action='store_true',
+        dest='ignore_declined',
+        default=False,
+        help='Hide events that have been declined',
+    )
     auto_width = get_auto_width()
     output_parser.add_argument(
-            '--width', '-w', default=auto_width, dest='cal_width',
-            type=validwidth, help='Set output width')
+        '--width',
+        '-w',
+        default=auto_width,
+        dest='cal_width',
+        type=validwidth,
+        help='Set output width',
+    )
     has_24_hours = locale_has_24_hours()
     output_parser.add_argument(
-            '--military', action='store_true', default=has_24_hours,
-            help='Use 24 hour display')
+        '--military',
+        action='store_true',
+        default=has_24_hours,
+        help='Use 24 hour display',
+    )
     output_parser.add_argument(
-            '--no-military', action='store_false', default=has_24_hours,
-            help='Use 12 hour display', dest='military')
+        '--no-military',
+        action='store_false',
+        default=has_24_hours,
+        help='Use 12 hour display',
+        dest='military',
+    )
     output_parser.add_argument(
-            '--override-color', action='store_true', default=False,
-            help='Use overridden color for event')
+        '--override-color',
+        action='store_true',
+        default=False,
+        help='Use overridden color for event',
+    )
     return output_parser
 
 
@@ -235,18 +264,25 @@ def get_color_parser():
 def get_remind_parser():
     remind_parser = argparse.ArgumentParser(add_help=False)
     remind_parser.add_argument(
-            '--reminder', default=[], type=validreminder, dest='reminders',
-            action='append',
-            help='Reminders in the form "TIME METH" or "TIME".  TIME '
-            'is a number which may be followed by an optional '
-            '"w", "d", "h", or "m" (meaning weeks, days, hours, '
-            'minutes) and default to minutes.  METH is a string '
-            '"popup", "email", or "sms" and defaults to popup.')
+        '--reminder',
+        default=[],
+        type=validreminder,
+        dest='reminders',
+        action='append',
+        help='Reminders in the form "TIME METH" or "TIME".  TIME '
+        'is a number which may be followed by an optional '
+        '"w", "d", "h", or "m" (meaning weeks, days, hours, '
+        'minutes) and default to minutes.  METH is a string '
+        '"popup", "email", or "sms" and defaults to popup.',
+    )
     remind_parser.add_argument(
-            '--default-reminders', action='store_true',
-            dest='default_reminders', default=False,
-            help='If no --reminder is given, use the defaults.  If this is '
-            'false, do not create any reminders.')
+        '--default-reminders',
+        action='store_true',
+        dest='default_reminders',
+        default=False,
+        help='If no --reminder is given, use the defaults.  If this is '
+        'false, do not create any reminders.',
+    )
     return remind_parser
 
 
@@ -260,10 +296,15 @@ def get_cal_query_parser():
         dest='week_start',
         # Note defaults to SUNDAY via config.OutputSection (not explicitly set
         # here because that would override value from config).
-        help='Start the week on Monday')
+        help='Start the week on Monday',
+    )
     cal_query_parser.add_argument(
-        '--noweekend', action='store_false', dest='cal_weekend',
-        default=True,  help='Hide Saturday and Sunday')
+        '--noweekend',
+        action='store_false',
+        dest='cal_weekend',
+        default=True,
+        help='Hide Saturday and Sunday',
+    )
     return cal_query_parser
 
 
@@ -271,8 +312,8 @@ def get_updates_parser():
     updates_parser = argparse.ArgumentParser(add_help=False)
     updates_parser.add_argument('since', type=utils.get_time_from_str)
     updates_parser.add_argument(
-            'start',
-            type=utils.get_time_from_str, nargs='?')
+        'start', type=utils.get_time_from_str, nargs='?'
+    )
     updates_parser.add_argument('end', type=utils.get_time_from_str, nargs='?')
     return updates_parser
 
@@ -282,9 +323,11 @@ def get_conflicts_parser():
     conflicts_parser = argparse.ArgumentParser(add_help=False)
     conflicts_parser.add_argument('text', nargs='?', type=str)
     conflicts_parser.add_argument(
-            'start', type=utils.get_time_from_str, nargs='?')
+        'start', type=utils.get_time_from_str, nargs='?'
+    )
     conflicts_parser.add_argument(
-            'end', type=utils.get_time_from_str, nargs='?')
+        'end', type=utils.get_time_from_str, nargs='?'
+    )
     return conflicts_parser
 
 
@@ -299,8 +342,7 @@ def get_search_parser():
     # requires search text, optional start and end filters
     search_parser = argparse.ArgumentParser(add_help=False)
     search_parser.add_argument('text', nargs=1)
-    search_parser.add_argument(
-            'start', type=utils.get_time_from_str, nargs='?')
+    search_parser.add_argument('start', type=utils.get_time_from_str, nargs='?')
     search_parser.add_argument('end', type=utils.get_time_from_str, nargs='?')
     return search_parser
 
@@ -376,8 +418,10 @@ def get_argument_parser():
     )
 
     parser.add_argument(
-            '--version', action='version', version='%%(prog)s %s (%s)' %
-            (gcalcli.__version__, gcalcli.__author__))
+        '--version',
+        action='version',
+        version='%%(prog)s %s (%s)' % (gcalcli.__version__, gcalcli.__author__),
+    )
 
     # Program level options
     for option, definition in PROGRAM_OPTIONS.items():
@@ -402,9 +446,10 @@ def get_argument_parser():
     search_parser = get_search_parser()
 
     sub = parser.add_subparsers(
-            help='Invoking a subcommand with --help prints subcommand usage.',
-            dest='command',
-            required=True)
+        help='Invoking a subcommand with --help prints subcommand usage.',
+        dest='command',
+        required=True,
+    )
 
     sub.add_parser(
         'init',
@@ -451,7 +496,8 @@ def get_argument_parser():
         'interactively.',
     )
     delete.add_argument(
-            '--iamaexpert', action='store_true', help='Probably not')
+        '--iamaexpert', action='store_true', help='Probably not'
+    )
 
     sub.add_parser(
         'agenda',
@@ -475,7 +521,8 @@ def get_argument_parser():
         'file',
         type=argparse.FileType('r', errors='replace'),
         nargs='?',
-        default=sys.stdin)
+        default=sys.stdin,
+    )
 
     sub.add_parser(
         'updates',
@@ -548,38 +595,58 @@ def get_argument_parser():
         'remaining data.',
     )
     add.add_argument(
-            '--color',
-            dest='event_color',
-            default=None, type=str,
-            help='Color of event in browser (overrides default). Choose '
-                 'from lavender, sage, grape, flamingo, banana, tangerine, '
-                 'peacock, graphite, blueberry, basil, tomato.'
+        '--color',
+        dest='event_color',
+        default=None,
+        type=str,
+        help='Color of event in browser (overrides default). Choose '
+        'from lavender, sage, grape, flamingo, banana, tangerine, '
+        'peacock, graphite, blueberry, basil, tomato.',
     )
     add.add_argument('--title', default=None, type=str, help='Event title')
     add.add_argument(
-            '--who', default=[], type=str, action='append',
-            help='Event participant (may be provided multiple times)')
+        '--who',
+        default=[],
+        type=str,
+        action='append',
+        help='Event participant (may be provided multiple times)',
+    )
     add.add_argument('--where', default=None, type=str, help='Event location')
     add.add_argument('--when', default=None, type=str, help='Event time')
     # Allow either --duration or --end, but not both.
     end_group = add.add_mutually_exclusive_group()
     end_group.add_argument(
-        '--duration', default=None, type=int,
+        '--duration',
+        default=None,
+        type=int,
         help='Event duration in minutes (or days if --allday is given). '
-        'Alternative to --end.')
+        'Alternative to --end.',
+    )
     end_group.add_argument(
-        '--end', default=None, type=str,
-        help='Event ending time. Alternative to --duration.')
+        '--end',
+        default=None,
+        type=str,
+        help='Event ending time. Alternative to --duration.',
+    )
     add.add_argument(
-        '--description', default=None, type=str, help='Event description')
+        '--description', default=None, type=str, help='Event description'
+    )
     add.add_argument(
-        '--allday', action='store_true', dest='allday', default=False,
+        '--allday',
+        action='store_true',
+        dest='allday',
+        default=False,
         help='If --allday is given, the event will be an all-day event '
         '(possibly multi-day if --duration is greater than 1). The time part '
-        'of the --when will be ignored.')
+        'of the --when will be ignored.',
+    )
     add.add_argument(
-        '--noprompt', action='store_false', dest='prompt', default=True,
-        help='Don\'t prompt for missing data when adding events')
+        '--noprompt',
+        action='store_false',
+        dest='prompt',
+        default=True,
+        help='Don\'t prompt for missing data when adding events',
+    )
 
     _import = sub.add_parser(
         'import',
@@ -590,15 +657,20 @@ def get_argument_parser():
         'provided.',
     )
     _import.add_argument(
-            'file',
-            type=argparse.FileType('r', errors='replace'),
-            nargs='?',
-            default=None)
+        'file',
+        type=argparse.FileType('r', errors='replace'),
+        nargs='?',
+        default=None,
+    )
     _import.add_argument(
-        '--verbose', '-v', action='count', help='Be verbose on imports')
+        '--verbose', '-v', action='count', help='Be verbose on imports'
+    )
     _import.add_argument(
-        '--dump', '-d', action='store_true',
-        help='Print events and don\'t import')
+        '--dump',
+        '-d',
+        action='store_true',
+        help='Print events and don\'t import',
+    )
     _import.add_argument(
         '--use-legacy-import',
         action='store_true',
@@ -620,12 +692,14 @@ def get_argument_parser():
     remind.add_argument('cmd', nargs='?', type=str, default=default_cmd)
 
     remind.add_argument(
-            '--use-reminders', action='store_true',
-            help='Honor the remind time when running remind command')
+        '--use-reminders',
+        action='store_true',
+        help='Honor the remind time when running remind command',
+    )
 
     remind.add_argument(
-            '--use_reminders', action=DeprecatedStoreTrue,
-            help=argparse.SUPPRESS)
+        '--use_reminders', action=DeprecatedStoreTrue, help=argparse.SUPPRESS
+    )
 
     config = sub.add_parser(
         'config',

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -42,7 +42,7 @@ PROGRAM_OPTIONS = {
     '--noincluderc': {
         'action': 'store_false',
         'dest': 'includeRc',
-        'help': 'Whether to include ~/.gcalclirc when using configFolder',
+        'help': 'Whether to include ~/.gcalclirc.',
     },
     '--calendar': {
         'default': [],

--- a/tests/cli/__snapshot__/test-02-test_prints_correct_help.snap
+++ b/tests/cli/__snapshot__/test-02-test_prints_correct_help.snap
@@ -78,8 +78,8 @@ options:
                         Optional directory used to load config files.
                         Deprecated: prefer $GCALCLI_CONFIG. (default:
                         /some/gcalcli/config)
-  --noincluderc         Whether to include ~/.gcalclirc when using
-                        configFolder (default: True)
+  --noincluderc         Whether to include ~/.gcalclirc. (default:
+                        True)
   --calendar CALENDAR   Which calendars to use, in the format
                         "CalendarName" or "CalendarName#color", where
                         the #color suffix is the name of a valid ANSI

--- a/tests/cli/__snapshot__/test-02-test_prints_correct_help.snap
+++ b/tests/cli/__snapshot__/test-02-test_prints_correct_help.snap
@@ -2,7 +2,7 @@
 usage: gcalcli [-h] [--version] [--client-id CLIENT_ID]
                [--client-secret CLIENT_SECRET] [--noauth_local_server]
                [--config-folder CONFIG_FOLDER] [--noincluderc]
-               [--calendar CALENDAR]
+               [--calendar GLOBAL_CALENDARS]
                [--default-calendar DEFAULT_CALENDARS]
                [--locale LOCALE] [--refresh] [--nocache] [--conky]
                [--nocolor] [--lineart {fancy,unicode,ascii}]
@@ -80,12 +80,13 @@ options:
                         /some/gcalcli/config)
   --noincluderc         Whether to include ~/.gcalclirc. (default:
                         True)
-  --calendar CALENDAR   Which calendars to use, in the format
-                        "CalendarName" or "CalendarName#color", where
-                        the #color suffix is the name of a valid ANSI
-                        color (such as "brightblue"). This option may
-                        be called multiple times to display additional
-                        calendars. (default: [])
+  --calendar GLOBAL_CALENDARS
+                        Which calendars to use, in the format
+                        "CalendarName" or "CalendarName#color".
+                        Supported here globally for compatibility
+                        purposes, but prefer passing to individual
+                        commands after the command name since this
+                        global version is brittle. (default: [])
   --default-calendar DEFAULT_CALENDARS
                         Optional default calendar to use if no
                         --calendar options are given (default: [])

--- a/tests/test_argparsers.py
+++ b/tests/test_argparsers.py
@@ -100,4 +100,4 @@ def test_handle_unparsed():
     argv = shlex.split('delete --calendar=test "search text"')
     parsed, unparsed = parser.parse_known_args(argv)
     parsed = argparsers.handle_unparsed(unparsed, parsed)
-    assert parsed.calendar == ['test']
+    assert parsed.calendars == ['test']


### PR DESCRIPTION
Updates handling of --calendar to stop relying on brittle handle_unparsed hack and use more self-aware parsing per command.

Also updates --noincluderc to work more comprehensively (w/ or w/o --config-folder), so that it's easier to ensure other calendars listed in configs don't leak into a given gcalcli run.

Fixes #697 and #757.