### PR TITLE
Determine date format to use based on system locale's in "When" inputs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ v4.5.0
     w/ or w/o --config-folder
     - POSSIBLE ACTION REQUIRED: Use `@path/to/gcalclirc` explicitly if it stops
       reading an rc file you needed
+  * Determine date format to use based on system locale's in "When" inputs
   * Respect locally-installed certificates (ajkessel)
   * Re-add a `--noauth_local_server` to provide instructions for authenticating
     from a remote system using port forwarding

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -36,8 +36,15 @@ from .argparsers import get_argument_parser, handle_unparsed
 from .exceptions import GcalcliError
 from .gcal import GoogleCalendarInterface
 from .printer import Printer, valid_color_name
-from .validators import (get_input, PARSABLE_DATE, PARSABLE_DURATION, REMINDER,
-                         STR_ALLOW_EMPTY, STR_NOT_EMPTY)
+from .validators import (
+    DATETIME_INPUT_DESCRIPTION,
+    get_input,
+    PARSABLE_DATE,
+    PARSABLE_DURATION,
+    REMINDER,
+    STR_ALLOW_EMPTY,
+    STR_NOT_EMPTY,
+)
 
 CalName = namedtuple('CalName', ['name', 'color'])
 
@@ -108,7 +115,12 @@ def run_add_prompt(parsed_args, printer):
     if parsed_args.where is None:
         parsed_args.where = get_input(printer, 'Location: ', STR_ALLOW_EMPTY)
     if parsed_args.when is None:
-        parsed_args.when = get_input(printer, 'When: ', PARSABLE_DATE)
+        parsed_args.when = get_input(
+            printer,
+            'When (? for help): ',
+            PARSABLE_DATE,
+            help=f'Expected format: {DATETIME_INPUT_DESCRIPTION}',
+        )
     if parsed_args.duration is None and parsed_args.end is None:
         if parsed_args.allday:
             prompt = 'Duration (days): '

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -37,7 +37,7 @@ from .exceptions import GcalcliError
 from .gcal import GoogleCalendarInterface
 from .printer import Printer, valid_color_name
 from .validators import (
-    DATETIME_INPUT_DESCRIPTION,
+    get_date_input_description,
     get_input,
     PARSABLE_DATE,
     PARSABLE_DURATION,
@@ -115,11 +115,12 @@ def run_add_prompt(parsed_args, printer):
     if parsed_args.where is None:
         parsed_args.where = get_input(printer, 'Location: ', STR_ALLOW_EMPTY)
     if parsed_args.when is None:
+        date_format_desc = get_date_input_description()
         parsed_args.when = get_input(
             printer,
             'When (? for help): ',
             PARSABLE_DATE,
-            help=f'Expected format: {DATETIME_INPUT_DESCRIPTION}',
+            help=f'Expected format: {date_format_desc}',
         )
     if parsed_args.duration is None and parsed_args.end is None:
         if parsed_args.allday:

--- a/gcalcli/validators.py
+++ b/gcalcli/validators.py
@@ -2,16 +2,18 @@ import re
 from typing import Optional
 
 from .exceptions import ValidationError
-from .utils import get_time_from_str, get_timedelta_from_str, REMINDER_REGEX
+from .utils import (
+    get_time_from_str,
+    get_timedelta_from_str,
+    REMINDER_REGEX,
+    is_dayfirst_locale,
+)
 
 # TODO: in the future, pull these from the API
 # https://developers.google.com/calendar/v3/reference/colors
 VALID_OVERRIDE_COLORS = ['lavender', 'sage', 'grape', 'flamingo',
                          'banana', 'tangerine', 'peacock', 'graphite',
                          'blueberry', 'basil', 'tomato']
-
-DATETIME_INPUT_DESCRIPTION = 'a date (e.g. 2019-12-31, tomorrow 10am, 2nd Jan, \
-Jan 4th, etc) or valid time if today'
 
 
 def get_override_color_id(color):
@@ -66,6 +68,13 @@ def str_to_int_validator(input_str):
         )
 
 
+def get_date_input_description():
+    dayfirst = is_dayfirst_locale()
+    sample_date = '2019-31-12' if dayfirst else '2019-12-31'
+    return f'a date (e.g. {sample_date}, tomorrow 10am, 2nd Jan, Jan 4th, etc) \
+or valid time if today'
+
+
 def parsable_date_validator(input_str):
     """
     A filter allowing any string which can be parsed
@@ -76,8 +85,9 @@ def parsable_date_validator(input_str):
         get_time_from_str(input_str)
         return input_str
     except ValueError:
+        format_desc = get_date_input_description()
         raise ValidationError(
-            f'Expected format: {DATETIME_INPUT_DESCRIPTION}. '
+            f'Expected format: {format_desc}. '
             '(Ctrl-C to exit)\n'
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "argcomplete",
+  "babel",
   "google-api-python-client>=1.4",
   "google_auth_oauthlib",
   "httplib2",

--- a/tests/cli/__snapshot__/test-04-test_can_run_add.snap
+++ b/tests/cli/__snapshot__/test-04-test_can_run_add.snap
@@ -2,4 +2,4 @@
 Running in GCALCLI_USERLESS_MODE. Most operations will fail!
 [0mPrompting for unfilled values.
 Run with --noprompt to leave them unfilled without prompting.
-[0m[0;35mTitle: [0m[0;35mLocation: [0m[0;35mWhen: [0m[0;35mDuration (human readable): [0m[0;35mDescription: [0m[0;35mEnter a valid reminder or "." to end: [0m[31;1mNo available calendar to use[0m
+[0m[0;35mTitle: [0m[0;35mLocation: [0m[0;35mWhen (? for help): [0m[0;35mDuration (human readable): [0m[0;35mDescription: [0m[0;35mEnter a valid reminder or "." to end: [0m[31;1mNo available calendar to use[0m

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -2,7 +2,7 @@ import pytest
 
 from gcalcli.validators import (PARSABLE_DATE, PARSABLE_DURATION, REMINDER,
                                 STR_ALLOW_EMPTY, STR_NOT_EMPTY, STR_TO_INT,
-                                VALID_COLORS, validate_input, ValidationError)
+                                VALID_COLORS, ValidationError)
 
 # Tests required:
 #
@@ -19,25 +19,25 @@ def test_any_string_not_blank_validator(monkeypatch):
     # Empty string raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "")
     with pytest.raises(ValidationError):
-        validate_input(STR_NOT_EMPTY) == ValidationError(
+        STR_NOT_EMPTY(input()) == ValidationError(
             "Input here cannot be empty")
 
     # None raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: None)
     with pytest.raises(ValidationError):
-        validate_input(STR_NOT_EMPTY) == ValidationError(
+        STR_NOT_EMPTY(input()) == ValidationError(
             "Input here cannot be empty")
 
     # Valid string passes
     monkeypatch.setattr("builtins.input", lambda: "Valid Text")
-    assert validate_input(STR_NOT_EMPTY) == "Valid Text"
+    assert STR_NOT_EMPTY(input()) == "Valid Text"
 
 
 def test_any_string_parsable_by_dateutil(monkeypatch):
     # non-date raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "NON-DATE STR")
     with pytest.raises(ValidationError):
-        validate_input(PARSABLE_DATE) == ValidationError(
+        PARSABLE_DATE(input()) == ValidationError(
             "Expected format: a date (e.g. 2019-01-01, tomorrow 10am, "
             "2nd Jan, Jan 4th, etc) or valid time if today. "
             "(Ctrl-C to exit)\n"
@@ -45,14 +45,14 @@ def test_any_string_parsable_by_dateutil(monkeypatch):
 
     # date string passes
     monkeypatch.setattr("builtins.input", lambda: "2nd January")
-    validate_input(PARSABLE_DATE) == "2nd January"
+    PARSABLE_DATE(input()) == "2nd January"
 
 
 def test_any_string_parsable_by_parsedatetime(monkeypatch):
     # non-date raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "NON-DATE STR")
     with pytest.raises(ValidationError) as ve:
-        validate_input(PARSABLE_DURATION)
+        PARSABLE_DURATION(input())
     assert ve.value.message == (
             'Expected format: a duration (e.g. 1m, 1s, 1h3m)'
             '(Ctrl-C to exit)\n'
@@ -60,71 +60,71 @@ def test_any_string_parsable_by_parsedatetime(monkeypatch):
 
     # duration string passes
     monkeypatch.setattr("builtins.input", lambda: "1m")
-    assert validate_input(PARSABLE_DURATION) == "1m"
+    assert PARSABLE_DURATION(input()) == "1m"
 
     # duration string passes
     monkeypatch.setattr("builtins.input", lambda: "1h2m")
-    assert validate_input(PARSABLE_DURATION) == "1h2m"
+    assert PARSABLE_DURATION(input()) == "1h2m"
 
 
 def test_string_can_be_cast_to_int(monkeypatch):
     # non int-castable string raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "X")
     with pytest.raises(ValidationError):
-        validate_input(STR_TO_INT) == ValidationError(
+        STR_TO_INT(input()) == ValidationError(
             "Input here must be a number")
 
     # int string passes
     monkeypatch.setattr("builtins.input", lambda: "10")
-    validate_input(STR_TO_INT) == "10"
+    STR_TO_INT(input()) == "10"
 
 
 def test_for_valid_colour_name(monkeypatch):
     # non valid colour raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "purple")
     with pytest.raises(ValidationError):
-        validate_input(VALID_COLORS) == ValidationError(
+        VALID_COLORS(input()) == ValidationError(
             "purple is not a valid color value to use here. Please "
             "use one of basil, peacock, grape, lavender, blueberry,"
             "tomato, safe, flamingo or banana."
         )
     # valid colour passes
     monkeypatch.setattr("builtins.input", lambda: "grape")
-    validate_input(VALID_COLORS) == "grape"
+    VALID_COLORS(input()) == "grape"
 
     # empty str passes
     monkeypatch.setattr("builtins.input", lambda: "")
-    validate_input(VALID_COLORS) == ""
+    VALID_COLORS(input()) == ""
 
 
 def test_any_string_and_blank(monkeypatch):
     # string passes
     monkeypatch.setattr("builtins.input", lambda: "TEST")
-    validate_input(STR_ALLOW_EMPTY) == "TEST"
+    STR_ALLOW_EMPTY(input()) == "TEST"
 
 
 def test_reminder(monkeypatch):
     # valid reminders pass
     monkeypatch.setattr("builtins.input", lambda: "10m email")
-    validate_input(REMINDER) == "10m email"
+    REMINDER(input()) == "10m email"
 
     monkeypatch.setattr("builtins.input", lambda: "10 popup")
-    validate_input(REMINDER) == "10m email"
+    REMINDER(input()) == "10m email"
 
     monkeypatch.setattr("builtins.input", lambda: "10m sms")
-    validate_input(REMINDER) == "10m email"
+    REMINDER(input()) == "10m email"
 
     monkeypatch.setattr("builtins.input", lambda: "12323")
-    validate_input(REMINDER) == "10m email"
+    REMINDER(input()) == "10m email"
 
     # invalid reminder raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "meaningless")
     with pytest.raises(ValidationError):
-        validate_input(REMINDER) == ValidationError(
+        REMINDER(input()) == ValidationError(
             "Format: <number><w|d|h|m> <popup|email|sms>\n")
 
     # invalid reminder raises ValidationError
     monkeypatch.setattr("builtins.input", lambda: "")
     with pytest.raises(ValidationError):
-        validate_input(REMINDER) == ValidationError(
+        REMINDER(input()) == ValidationError(
             "Format: <number><w|d|h|m> <popup|email|sms>\n")


### PR DESCRIPTION
Fixes #542.
Fixes #143.

Note: This adds a new dependency on [babel](https://pypi.org/project/babel/), which isn't tiny. _COULD_ convert that to optional-dependencies if absolutely needed, but I'd prefer to keep it an unconditional dep since i18n/l10n are pretty important aspects of a tool like gcalcli.