### PR TITLE
CreateEventFromVOBJ: if there is no dtend, use the duration if available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ v4.5.0
       reading an rc file you needed
   * The `import` command now dumps events it couldn't import into a tmp rej.ics
     file in a tmp directory for convenient retries
+  * `import` can also handle events w/o a dtend, using duration if available
   * Determine date format to use based on system locale's in "When" inputs
   * Respect locally-installed certificates (ajkessel)
   * Re-add a `--noauth_local_server` to provide instructions for authenticating

--- a/gcalcli/ics.py
+++ b/gcalcli/ics.py
@@ -123,7 +123,11 @@ def CreateEventFromVOBJ(
         if hasattr(ve, 'duration') and ve.duration.value:
             duration = ve.duration.value
         else:
-            duration = timedelta(minutes=0)
+            printer.msg(
+                "Falling back to 30m duration for imported event w/o "
+                "explicit duration or end.\n"
+            )
+            duration = timedelta(minutes=30)
         if verbose:
             print('Duration.....%s' % duration)
         end = ve.dtstart.value + duration


### PR DESCRIPTION
Fixes #486.

Credit: Changes taken from #282 and rebased onto main, with trivial cleanups and a tweak to the dtstart-only case (30m duration + info message instead of 0m duration).