### PR TITLE
Add --use-legacy-import hint message in `import` partial-failure output

### DIFF
--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1652,5 +1652,12 @@ class GoogleCalendarInterface:
                 f"Dumped {len(failed_events)} failed events to "
                 f"{ics_dump_path!s}.\n"
             )
+            self.printer.msg(
+                "\n"
+                "Note: you can try reprocessing this file with `gcalcli "
+                "import --use-legacy-import` to work around some failure "
+                "causes (but with potentially noisier update notifications)."
+                "\n",
+            )
 
         return True


### PR DESCRIPTION
Helps #730 (by making workaround more discoverable).