### PR TITLE
Simplify --version to omit author names

### DIFF
--- a/gcalcli/__init__.py
+++ b/gcalcli/__init__.py
@@ -6,4 +6,3 @@ except ImportError:
     __version__ = '__unknown__'
 
 __program__ = 'gcalcli'
-__author__ = 'Eric Davis, Brian Hartvigsen, Joshua Crowgey'

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -420,7 +420,7 @@ def get_argument_parser():
     parser.add_argument(
         '--version',
         action='version',
-        version='%%(prog)s %s (%s)' % (gcalcli.__version__, gcalcli.__author__),
+        version=f'%(prog)s {gcalcli.__version__}',
     )
 
     # Program level options

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -12,9 +12,10 @@
 #                | (_ | | (__  / _ \  | |__ | (__ | |__  | |                #
 #                 \___|  \___|/_/ \_\ |____| \___||____||___|               #
 #                                                                           #
-# Authors: Eric Davis <http://www.insanum.com>                              #
-#          Brian Hartvigsen <http://github.com/tresni>                      #
-#          Joshua Crowgey <http://github.com/jcrowgey>                      #
+# Authors: Eric Davis <https://www.insanum.com>                             #
+#          Brian Hartvigsen <https://github.com/tresni>                     #
+#          Joshua Crowgey <https://github.com/jcrowgey>                     #
+# Maintainers: David Barnett <https://github.com/dbarnett>                  #
 # Home: https://github.com/insanum/gcalcli                                  #
 #                                                                           #
 # Everything you need to know (Google API Calendar v3): http://goo.gl/HfTGQ #


### PR DESCRIPTION
I'm **not planning to merge this** without explicit :+1: from authors, but wanted to make _some_ kind of tweak to the `--version` output to better reflect the community maintenance of recent gcalcli versions. Not sure the exact convention for including author names in `--version` output, but it seemed simplest to just omit author info here instead of trying to reflect `authors: X, Y, Z; maintainers: A, B`.

Note authors are still listed in the man page and I'm not worried about changing that (since we already list the bug tracker for reaching maintainers).