### PR TITLE
 agenda and agendaupdate: add --details length redux

### DIFF
--- a/gcalcli/actions.py
+++ b/gcalcli/actions.py
@@ -12,6 +12,21 @@ def _iter_field_handlers(row):
         yield fieldname, handler, value
 
 
+def _check_writable_fields(row):
+    """Check no potentially conflicting fields for a writing action."""
+    keys = row.keys()
+
+    # XXX: instead of preventing use of end_date/end_time and length in the
+    # same input, use successively complex conflict resolution plans:
+    #
+    # 1. allow it as long as they don't conflict by row
+    # 2. conflict resolution by option
+    # 3. conflict resolution interactively
+
+    if 'length' in keys and ('end_date' in keys or 'end_time' in keys):
+        raise NotImplementedError
+
+
 def patch(row, cal, interface):
     """Patch event with new data."""
     event_id = row['id']
@@ -21,6 +36,8 @@ def patch(row, cal, interface):
     curr_event = None
     mod_event = {}
     cal_id = cal['id']
+
+    _check_writable_fields(row)
 
     for fieldname, handler, value in _iter_field_handlers(row):
         if fieldname in FIELDNAMES_READONLY:
@@ -55,6 +72,8 @@ def insert(row, cal, interface):
     """Insert new event."""
     event = {}
     cal_id = cal['id']
+
+    _check_writable_fields(row)
 
     for fieldname, handler, value in _iter_field_handlers(row):
         if fieldname in FIELDNAMES_READONLY:

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -124,6 +124,20 @@ class Time(Handler):
             instant['timeZone'] = cal['timeZone']
 
 
+class Length(Handler):
+    """Handler for event duration."""
+
+    fieldnames = ['length']
+
+    @classmethod
+    def get(cls, event):
+        return [str(event['e'] - event['s'])]
+
+    @classmethod
+    def patch(cls, cal, event, fieldname, value):
+        raise NotImplementedError
+
+
 class Url(Handler):
     """Handler for HTML and legacy Hangout links."""
 
@@ -259,6 +273,7 @@ class Action(SimpleSingleFieldHandler):
 
 HANDLERS = OrderedDict([('id', ID),
                         ('time', Time),
+                        ('length', Length),
                         ('url', Url),
                         ('conference', Conference),
                         ('title', Title),
@@ -279,8 +294,7 @@ FIELDNAMES_READONLY = frozenset(fieldname
                                 in FIELD_HANDLERS.items()
                                 if handler in HANDLERS_READONLY)
 
-_DETAILS_WITHOUT_HANDLERS = ['length', 'reminders', 'attendees',
-                             'attachments', 'end']
+_DETAILS_WITHOUT_HANDLERS = ['reminders', 'attendees', 'attachments', 'end']
 
 DETAILS = list(HANDLERS.keys()) + _DETAILS_WITHOUT_HANDLERS
 DETAILS_DEFAULT = {'time', 'title'}


### PR DESCRIPTION
Implements #791. Resubmission of accidentally closed pull request #817.

To eliminate the possibility of conflicts between `length` and `end_date`/`end_time`, this raises `NotImplementedError` if input is supplied with both of the fields.

In the future, the following would be better conflict resolution approaches:

1. allow both end fields and length field long as they are consistent in each row
2. conflict resolution by command-line option (e.g. prefer end fields or prefer length field)
3. conflict resolution interactively