### PR TITLE
Fix width argument, set overall width

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -108,9 +108,10 @@ class DetailsAction(argparse._AppendAction):
 
 
 def validwidth(value):
+    minwidth=30
     ival = int(value)
-    if ival < 10:
-        raise argparse.ArgumentTypeError('Width must be a number >= 10')
+    if ival < minwidth:
+        raise argparse.ArgumentTypeError(f'Width must be a number >= {minwidth}')
     return ival
 
 
@@ -146,9 +147,7 @@ def locale_has_24_hours():
 
 
 def get_auto_width():
-    console_width = get_terminal_size().columns
-    day_width = int((console_width - 8) / 7)
-    return day_width if day_width > 9 else 10
+    return get_terminal_size().columns
 
 
 def get_calendars_parser(nargs_multiple: bool) -> argparse.ArgumentParser:
@@ -204,12 +203,11 @@ def get_output_parser(parents=[]):
         default=False,
         help='Hide events that have been declined',
     )
-    auto_width = get_auto_width()
     output_parser.add_argument(
         '--width',
         '-w',
-        default=auto_width,
-        dest='cal_width',
+        default=get_auto_width(),
+        dest='width',
         type=validwidth,
         help='Set output width',
     )

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -111,7 +111,9 @@ def validwidth(value):
     minwidth=30
     ival = int(value)
     if ival < minwidth:
-        raise argparse.ArgumentTypeError(f'Width must be a number >= {minwidth}')
+        raise argparse.ArgumentTypeError(
+            'Width must be a number >= %d' % minwidth
+        )
     return ival
 
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -86,7 +86,7 @@ class GoogleCalendarInterface:
         # Store overall calendar width and width for day table cells
         self.width['cal'] = int(options.get('width', 80))
         day_width = int(( self.width['cal'] - 8) / 7)
-        # Mimimal day table cell is 10
+        # Minimal day table cell is 10
         self.width['day'] = day_width if day_width > 9 else 10
 
         if self.userless_mode:

--- a/tests/test_argparsers.py
+++ b/tests/test_argparsers.py
@@ -32,23 +32,23 @@ def test_output_parser(monkeypatch):
         return fake_get_terminal_size
 
     output_parser = argparsers.get_output_parser()
-    argv = shlex.split('-w 9')
+    argv = shlex.split('-w 29')
     with pytest.raises(SystemExit):
         output_parser.parse_args(argv)
 
-    argv = shlex.split('-w 10')
-    assert output_parser.parse_args(argv).cal_width == 10
+    argv = shlex.split('-w 30')
+    assert output_parser.parse_args(argv).width == 30
 
     argv = shlex.split('')
     monkeypatch.setattr(argparsers, 'get_terminal_size', sub_terminal_size(70))
     output_parser = argparsers.get_output_parser()
-    assert output_parser.parse_args(argv).cal_width == 10
+    assert output_parser.parse_args(argv).width == 70
 
     argv = shlex.split('')
     monkeypatch.setattr(argparsers, 'get_terminal_size',
                         sub_terminal_size(100))
     output_parser = argparsers.get_output_parser()
-    assert output_parser.parse_args(argv).cal_width == 13
+    assert output_parser.parse_args(argv).width == 100
 
 
 def test_search_parser():

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -86,7 +86,7 @@ def test_cal_query(capsys, PatchedGCalI):
     art = gcal.printer.art
     expect_top = (
             gcal.printer.colors[gcal.options['color_border']] + art['ulc'] +
-            art['hrz'] * gcal.options['cal_width'])
+            art['hrz'] * gcal.width['day'])
     assert captured.out.startswith(expect_top)
 
     gcal.CalQuery('calm')
@@ -348,13 +348,13 @@ def test_iterate_events(capsys, PatchedGCalI):
 def test_next_cut(PatchedGCalI):
     gcal = PatchedGCalI()
     # default width is 10
-    test_cal_width = 10
-    gcal.options['cal_width'] = test_cal_width
+    test_day_width = 10
+    gcal.width['day'] = test_day_width
     event_title = "first looooong"
     assert gcal._next_cut(event_title) == (5, 5)
 
-    event_title = "tooooooloooong"
-    assert gcal._next_cut(event_title) == (test_cal_width, test_cal_width)
+    event_title = "tooooooooooooooooooooooooloooooooooong"
+    assert gcal._next_cut(event_title) == (test_day_width, test_day_width)
 
     event_title = "one two three four"
     assert gcal._next_cut(event_title) == (7, 7)


### PR DESCRIPTION
Fix the width for the description details, both default and as cmdline option, and make sure we don't break the width of the `calw` and `calm` output.
The (pretty much undocumented) option` --width`/`-w` option was used for setting the width of a day table cell in `calw` and `calm` but seemed to also be intended for setting the overall width of the `description` in `agenda`. The latter part was broken and the details `description` width would always default to 80.
We change the behaviour to set the overall width of the table, defaulting to the terminal width, both for `calw` and `calm` and for `description` details. The width of the day cell is calculated from the overall width.