### PR TITLE
Add --json output option

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -192,6 +192,13 @@ def get_output_parser(parents=[]):
         help='Use Tab Separated Value output',
     )
     output_parser.add_argument(
+        '--json',
+        action='store_true',
+        dest='json',
+        default=False,
+        help='Use JSON output',
+    )
+    output_parser.add_argument(
         '--nostarted',
         action='store_true',
         dest='ignore_started',

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -207,6 +207,10 @@ class Conference(Handler):
 
     fieldnames = list(ENTRY_POINT_PROPS.keys())
 
+    CONFERENCE_PROPS = OrderedDict([('meeting_code', 'meetingCode'),
+                                    ('passcode', 'passcode'),
+                                    ('region_code', 'regionCode')])
+
     @classmethod
     def get(cls, event):
         if 'conferenceData' not in event:
@@ -220,6 +224,19 @@ class Conference(Handler):
 
         return [entry_point.get(prop, '')
                 for prop in ENTRY_POINT_PROPS.values()]
+
+    @classmethod
+    def data(cls, event):
+        if 'conferenceData' not in event:
+            return []
+
+        PROPS = {**ENTRY_POINT_PROPS, **cls.CONFERENCE_PROPS}
+
+        value = []
+        for entryPoint in event['conferenceData'].get('entryPoints', []):
+            value.append({key: entryPoint.get(prop, '').strip()
+                          for key, prop in PROPS.items()})
+        return value
 
     @classmethod
     def patch(cls, cal, event, fieldname, value):

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -137,7 +137,7 @@ class Time(Handler):
             instant['timeZone'] = cal['timeZone']
 
 
-class Length(Time):
+class Length(Handler):
     """Handler for event duration."""
 
     fieldnames = ['length']
@@ -300,7 +300,7 @@ class ID(SimpleSingleFieldHandler):
     fieldnames = ['id']
 
 
-class Action(SimpleSingleFieldHandler):
+class Action(SingleFieldHandler):
     """Handler specifying event processing during an update."""
 
     fieldnames = ['action']

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -749,6 +749,33 @@ class GoogleCalendarInterface:
             output = ('\t'.join(row)).replace('\n', r'\n')
             print(output)
 
+    def _json(self, start_datetime, event_list):
+        keys = set(self.details.keys())
+        keys.update(DETAILS_DEFAULT)
+
+        print("[")
+
+        first = True
+        for event in event_list:
+            if self.options['ignore_started'] and (event['s'] < self.now):
+                continue
+            if self.options['ignore_declined'] and self._DeclinedEvent(event):
+                continue
+
+            row = {}
+            #row['raw'] = event
+
+            for key in keys:
+                if key in HANDLERS:
+                    row[key] = HANDLERS[key].data(event)
+
+            if not first:
+                print(",")
+            first = False
+            print(json.dumps(row, default=str))
+
+        print("]")
+
     def _PrintEvent(self, event, prefix):
 
         def _format_descr(descr, indent, box):
@@ -1262,6 +1289,8 @@ class GoogleCalendarInterface:
 
         if self.options.get('tsv'):
             return self._tsv(start, event_list)
+        elif self.options.get('json'):
+            return self._json(start, event_list)
         else:
             return self._iterate_events(start, event_list, year_date=year_date)
 


### PR DESCRIPTION
This PR extends the `--tsv` output mechanism to provide an alternative `--json` output format.
Implements #466 

For consistency, anywhere where there's a json dict, the key names use the TSV column name.


As part of this,
* plumbed `attendees` detail handlers.  (`attendees` for TSV is semi-colon delimited email addresses)
* fixed some subclasses?
* `email` is more tolerant of creator/organizer 
