### PR TITLE
Include attachments in TSV and JSON formatted output

### DIFF
--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -414,7 +414,10 @@ class Attachments(Handler):
     @classmethod
     def patch(cls, cal, event, fieldname, value):
         # Attachments are read-only for now
-        raise ReadonlyCheckError(fieldname, cls.get(event), value)
+        current_value = cls.get(event)[0]
+
+        if current_value != value:
+            raise ReadonlyCheckError(fieldname, current_value, value)
 
 
 HANDLERS = OrderedDict([('id', ID),


### PR DESCRIPTION
Hello. This is a patch for https://github.com/insanum/gcalcli/issues/827. Following your lead in https://github.com/insanum/gcalcli/issues/829. Happy to continue iterating on this if you have any feedback. Thank you.



---

<!-- kody-pr-summary:start -->
The `Attachments.patch` method has been updated to refine its read-only behavior. Previously, any attempt to patch the `attachments` field would unconditionally raise a `ReadonlyCheckError`.

With this change, the method now first compares the provided `value` with the event's `current_value` for attachments. A `ReadonlyCheckError` is only raised if an actual modification is attempted (i.e., `current_value != value`). This allows for "patching" the attachments field with its existing value without triggering an error, while still preventing any actual changes to a different value.

New tests have been added to confirm this behavior, ensuring that patching with an unchanged value succeeds and patching with a different value correctly raises a `ReadonlyCheckError`.
<!-- kody-pr-summary:end -->