### PR TITLE
feat: add --availability flag (free/busy) for event transparency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769330179,
+        "narHash": "sha256-yxgb4AmkVHY5OOBrC79Vv6EVd4QZEotqv+6jcvA212M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48698d12cc10555a4f3e3222d9c669b884a49dfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -610,10 +610,10 @@ def get_argument_parser():
         'peacock, graphite, blueberry, basil, tomato.',
     )
     add.add_argument(
-        '--transparency',
-        default='opaque',
-        choices=['opaque', 'transparent'],
-        help='Event transparency (free/busy status). Default is opaque (busy).',
+        '--availability',
+        default='busy',
+        choices=['free', 'busy'],
+        help='Event availability (free/busy status). Default is busy.',
     )
     add.add_argument('--title', default=None, type=str, help='Event title')
     add.add_argument(

--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -609,6 +609,12 @@ def get_argument_parser():
         'from lavender, sage, grape, flamingo, banana, tangerine, '
         'peacock, graphite, blueberry, basil, tomato.',
     )
+    add.add_argument(
+        '--transparency',
+        default='opaque',
+        choices=['opaque', 'transparent'],
+        help='Event transparency (free/busy status). Default is opaque (busy).',
+    )
     add.add_argument('--title', default=None, type=str, help='Event title')
     add.add_argument(
         '--who',

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -305,7 +305,7 @@ def main():
             gcal.AddEvent(parsed_args.title, parsed_args.where, estart, eend,
                           parsed_args.description, parsed_args.who,
                           parsed_args.reminders, parsed_args.event_color,
-                          parsed_args.transparency)
+                          parsed_args.availability)
 
         elif parsed_args.command == 'search':
             gcal.TextQuery(

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -304,7 +304,8 @@ def main():
 
             gcal.AddEvent(parsed_args.title, parsed_args.where, estart, eend,
                           parsed_args.description, parsed_args.who,
-                          parsed_args.reminders, parsed_args.event_color)
+                          parsed_args.reminders, parsed_args.event_color,
+                          parsed_args.transparency)
 
         elif parsed_args.command == 'search':
             gcal.TextQuery(

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -356,6 +356,12 @@ class ID(SimpleSingleFieldHandler):
     fieldnames = ['id']
 
 
+class Transparency(SimpleSingleFieldHandler):
+    """Handler for event transparency (free/busy)."""
+
+    fieldnames = ['transparency']
+
+
 class Action(SingleFieldHandler):
     """Handler specifying event processing during an update."""
 
@@ -377,6 +383,7 @@ HANDLERS = OrderedDict([('id', ID),
                         ('calendar', Calendar),
                         ('email', Email),
                         ('attendees', Attendees),
+                        ('transparency', Transparency),
                         ('action', Action)])
 HANDLERS_READONLY = {Url, Calendar}
 

--- a/gcalcli/details.py
+++ b/gcalcli/details.py
@@ -356,10 +356,15 @@ class ID(SimpleSingleFieldHandler):
     fieldnames = ['id']
 
 
-class Transparency(SimpleSingleFieldHandler):
-    """Handler for event transparency (free/busy)."""
+class Availability(SimpleSingleFieldHandler):
+    """Handler for event availability (free/busy)."""
 
     fieldnames = ['transparency']
+
+    @classmethod
+    def _get(cls, event):
+        val = event.get(cls.fieldnames[0], 'opaque')
+        return 'free' if val == 'transparent' else 'busy'
 
 
 class Action(SingleFieldHandler):
@@ -383,7 +388,7 @@ HANDLERS = OrderedDict([('id', ID),
                         ('calendar', Calendar),
                         ('email', Email),
                         ('attendees', Attendees),
-                        ('transparency', Transparency),
+                        ('availability', Availability),
                         ('action', Action)])
 HANDLERS_READONLY = {Url, Calendar}
 

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1465,13 +1465,13 @@ class GoogleCalendarInterface:
         return new_event
 
     def AddEvent(self, title, where, start, end, descr, who, reminders, color,
-                 transparency='opaque'):
+                 availability='busy'):
 
         calendar = self._prompt_for_calendar(self.cals)
 
         event = {}
         event['summary'] = title
-        event['transparency'] = transparency
+        event['transparency'] = 'transparent' if availability == 'free' else 'opaque'
 
         if self.options['allday']:
             event['start'] = {'date': start}

--- a/gcalcli/gcal.py
+++ b/gcalcli/gcal.py
@@ -1464,12 +1464,14 @@ class GoogleCalendarInterface:
 
         return new_event
 
-    def AddEvent(self, title, where, start, end, descr, who, reminders, color):
+    def AddEvent(self, title, where, start, end, descr, who, reminders, color,
+                 transparency='opaque'):
 
         calendar = self._prompt_for_calendar(self.cals)
 
         event = {}
         event['summary'] = title
+        event['transparency'] = transparency
 
         if self.options['allday']:
             event['start'] = {'date': start}

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -393,3 +393,23 @@ def test_next_cut(PatchedGCalI):
 
     event_title = "樹貞 fun fun fun"
     assert gcal._next_cut(event_title) == (8, 6)
+
+def test_add_event_transparency(PatchedGCalI):
+    cal_names = parse_cal_names(['jcrowgey@uw.edu'], printer=None)
+    gcal = PatchedGCalI(
+            cal_names=cal_names, allday=False, default_reminders=True)
+    assert gcal.AddEvent(title='transparent event',
+                         where='anywhere',
+                         start='now',
+                         end='tomorrow',
+                         descr='testing',
+                         who='anyone',
+                         reminders=None,
+                         color='banana',
+                         transparency='transparent')
+
+    gcal.api_tracker.verify_all_mutating_calls([
+        CallMatcher('insert',
+                    body_has_fields={'summary', 'start', 'end', 'transparency'},
+                    body_fields={'transparency': 'transparent'})
+    ])

--- a/tests/test_gcalcli.py
+++ b/tests/test_gcalcli.py
@@ -394,7 +394,7 @@ def test_next_cut(PatchedGCalI):
     event_title = "樹貞 fun fun fun"
     assert gcal._next_cut(event_title) == (8, 6)
 
-def test_add_event_transparency(PatchedGCalI):
+def test_add_event_availability(PatchedGCalI):
     cal_names = parse_cal_names(['jcrowgey@uw.edu'], printer=None)
     gcal = PatchedGCalI(
             cal_names=cal_names, allday=False, default_reminders=True)
@@ -406,7 +406,7 @@ def test_add_event_transparency(PatchedGCalI):
                          who='anyone',
                          reminders=None,
                          color='banana',
-                         transparency='transparent')
+                         availability='free')
 
     gcal.api_tracker.verify_all_mutating_calls([
         CallMatcher('insert',


### PR DESCRIPTION
## Description

Adds a new `--availability` flag to the `add` command, allowing users to specify whether an event should show as "Free" or "Busy".

- **Option**: `--availability`
- **Choices**: `free`, `busy` (default: `busy`)
- **API Mapping**:
  - `free` → `transparency="transparent"`
  - `busy` → `transparency="opaque"`

## Motivation

This feature enables the creation of "Ghost Blocks" — events that are visible on the calendar for planning/context (e.g., "Deep Work", "Travel Time") but do not block availability for scheduling tools or colleagues.

## Changes

- **`gcalcli/argparsers.py`**: Added `--availability` argument.
- **`gcalcli/details.py`**: Added `Availability` handler to display "free"/"busy" status.
- **`gcalcli/gcal.py`**: Updated `AddEvent` to map the flag to the Google Calendar API `transparency` field.
- **`gcalcli/cli.py`**: Wired the argument to the backend.
- **`tests/test_gcalcli.py`**: Added regression test `test_add_event_availability`.

## Verification

- Verified with new automated test: `test_add_event_availability`.
- Verified manually specifically against the Google Calendar UI (events show as Free/Busy correctly).


---

<!-- kody-pr-summary:start -->
This pull request introduces the ability to specify an event's availability (free/busy status) when adding it.

Key changes include:
- **Added a `--availability` flag** to the `add` command, allowing users to set an event's status as `free` or `busy`. The default status is `busy`.
- **Integrated the availability setting** into the event creation logic, mapping `free` to Google Calendar's `transparent` status and `busy` to `opaque`.
- **Introduced an `Availability` handler** to correctly interpret and display the event's transparency status as `free` or `busy`.
- **Included a new test case** to verify that events added with `--availability free` are correctly marked as transparent in the Google Calendar API.
<!-- kody-pr-summary:end -->