### PR TITLE
Add global option for overriding timezone

### DIFF
--- a/gcalcli/argparsers.py
+++ b/gcalcli/argparsers.py
@@ -62,6 +62,7 @@ PROGRAM_OPTIONS = {
         'given',
     },
     '--locale': {'default': '', 'type': str, 'help': 'System locale'},
+    '--timezone': {'default': '', 'type': str, 'help': 'Timezone to use'},
     '--refresh': {
         'action': 'store_true',
         'dest': 'refresh_cache',

--- a/gcalcli/cli.py
+++ b/gcalcli/cli.py
@@ -37,6 +37,7 @@ import pathlib
 import re
 import signal
 import sys
+import time
 from argparse import ArgumentTypeError
 from collections import namedtuple
 
@@ -225,6 +226,10 @@ def main():
             utils.set_locale(parsed_args.locale)
         except ValueError as exc:
             printer.err_msg(str(exc))
+
+    if parsed_args.timezone:
+        os.environ['TZ'] = parsed_args.timezone
+        time.tzset()
 
     cal_names = set_resolved_calendars(parsed_args, printer=printer)
 


### PR DESCRIPTION
closes #320 

---

<!-- kody-pr-summary:start -->
This pull request introduces a new global command-line option, `--timezone`, allowing users to specify a timezone to be used by `gcalcli`.

When the `--timezone` option is provided, its value is used to set the `TZ` environment variable, effectively overriding the system's default timezone for the execution of the `gcalcli` command. This ensures that all time-related operations within `gcalcli` adhere to the specified timezone.
<!-- kody-pr-summary:end -->